### PR TITLE
feat(print): A4横1ページ収まりの印刷スタイル

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -25,13 +25,17 @@ textarea { width: 100%; font-size: 12px; }
 
 footer { text-align: right; }
 
-/* 印刷用（詳細は Issue #8 で仕上げ） */
+/* 印刷用（Issue #6: A4 横1ページ収まり） */
 @page { size: A4 landscape; margin: 8mm; }
 @media print {
   html, body { width: 297mm; height: 210mm; }
+  body { font-size: 11px; line-height: 1.2; }
+  header, footer { padding: 4mm 6mm; }
   .no-print { display: none !important; }
-  .grid { gap: 8px; }
+  .grid { gap: 6px; padding: 0 6mm 6mm; grid-template-columns: 2fr 1fr; }
+  .panel { break-inside: avoid; page-break-inside: avoid; }
   .slots { font-size: 10px; }
-  .slots input[type=text] { font-size: 10px; }
+  .slots th, .slots td { padding: 2px 4px; break-inside: avoid; page-break-inside: avoid; }
+  .slots input[type=text] { font-size: 10px; padding: 2px 2px; }
   * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 }


### PR DESCRIPTION
A4 横印刷で 1 ページに収めるためのスタイル調整です（Issue #6）。

- @page: A4 landscape + 8mm 余白
- 本文: フォント 11px / line-height 1.2、header/footer 余白圧縮
- レイアウト: grid ギャップ/パディング最適化（2fr:1fr）
- 分割抑止: .panel と .slots（table/row/cell）に break-inside / page-break-inside: avoid
- 入力欄: 印刷時フォント/パディング微調整（可読性）

印刷プレビューで 48 枠表と指標が A4 横 1 ページに収まることを確認しています。

Closes #6
