### PR TITLE
fix(ui): /dailylog 配下でCSS/APIが解決されない（絶対パス→相対パス）

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>生活行動表（日次）</title>
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header>
@@ -123,7 +123,7 @@
 
   async function load(){
     if(!/^\d{4}-\d{2}-\d{2}$/.test(dateEl.value)) return alert('日付が未指定');
-    const r = await fetch(`/api/day?date=${dateEl.value}`);
+    const r = await fetch(`api/day?date=${dateEl.value}`);
     const j = await r.json();
     inputs.forEach(inp=>{ inp.value=''; });
     (j.activities||[]).forEach(a=>{ if(inputs[a.slot]) inputs[a.slot].value = a.label||''; });
@@ -147,7 +147,7 @@
       note: noteEl.value,
       activities: inputs.map((inp,i)=>({ slot:i, label: inp.value.trim() })).filter(x=>x.label!=='')
     };
-    const r = await fetch('/api/day', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
+    const r = await fetch('api/day', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
     const j = await r.json();
     if(j.ok) alert('保存しました'); else alert('保存に失敗');
   }


### PR DESCRIPTION
Issue #17 の対応です。
- CSS と API の参照を相対パスに変更し、/dailylog 配下での公開に対応しました。
- ローカル開発( / )でも動作は変わりません。

変更点
- public/index.html
  - <link rel="stylesheet" href="/style.css"> → href="style.css"
  - fetch("/api/day" …) → fetch("api/day" …)

確認
- https://<HOST>/dailylog/ で CSS 200 / レイアウト適用を確認
- /dailylog/api/health へのアクセスはこれまで通り（認証あり）

関連: #17