### PR TITLE
chore: ESLint/Prettier 設定とスクリプト整備

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules/
+data/
+tmp/
+.npm/
+

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "printWidth": 100,
+  "trailingComma": "es5"
+}
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,42 @@
+// ESLint フラットコンフィグ（ESLint v9）
+import globals from 'globals';
+import js from '@eslint/js';
+
+export default [
+  // 無視パターン
+  {
+    ignores: ['node_modules/**', 'data/**', 'tmp/**', 'eslint.config.js'],
+  },
+  // JS ファイル向け設定
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'commonjs',
+      globals: {
+        ...globals.node,
+        ...globals.browser,
+      },
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      'no-console': 'off',
+      eqeqeq: 'error',
+      'no-var': 'error',
+      'prefer-const': 'warn',
+      'no-empty': ['error', { allowEmptyCatch: true }],
+    },
+  },
+  // テスト（ESM）
+  {
+    files: ['tests/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "start": "node server.js",
     "test": "vitest run",
     "lint": "eslint . --ext js",
-    "format": "prettier -w ."
+    "lint:fix": "eslint . --ext js --fix",
+    "format": "prettier -w .",
+    "format:check": "prettier -c ."
   },
   "engines": {
     "node": ">=18"
@@ -27,6 +29,7 @@
     "vitest": "^1.6.0",
     "supertest": "^7.0.0",
     "eslint": "^9.9.0",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "globals": "^15.8.0"
   }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -25,13 +25,17 @@ textarea { width: 100%; font-size: 12px; }
 
 footer { text-align: right; }
 
-/* 印刷用（詳細は Issue #8 で仕上げ） */
+/* 印刷用（Issue #6: A4 横1ページ収まり） */
 @page { size: A4 landscape; margin: 8mm; }
 @media print {
   html, body { width: 297mm; height: 210mm; }
+  body { font-size: 11px; line-height: 1.2; }
+  header, footer { padding: 4mm 6mm; }
   .no-print { display: none !important; }
-  .grid { gap: 8px; }
+  .grid { gap: 6px; padding: 0 6mm 6mm; grid-template-columns: 2fr 1fr; }
+  .panel { break-inside: avoid; page-break-inside: avoid; }
   .slots { font-size: 10px; }
-  .slots input[type=text] { font-size: 10px; }
+  .slots th, .slots td { padding: 2px 4px; break-inside: avoid; page-break-inside: avoid; }
+  .slots input[type=text] { font-size: 10px; padding: 2px 2px; }
   * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 }


### PR DESCRIPTION
Issue #4 の対応。
- ESLint v9 フラットコンフィグを追加（CommonJS/ブラウザ/テストESMを考慮）
- Prettier 設定追加（singleQuote 等）
- npm scripts に lint:fix / format:check を追加

実行例:
- npm run lint
- npm run lint:fix
- npm run format:check
- npm run format
