### PR TITLE
feat(ui): 横レイアウト（2列）＋区分ドロップダウン＋印刷パターン

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,15 +23,20 @@
     <section class="grid">
       <div class="panel">
         <h2>30分ごとの行動</h2>
-        <table id="slots" class="slots">
-          <thead>
-            <tr>
-              <th>時刻</th>
-              <th>内容</th>
-            </tr>
-          </thead>
-          <tbody id="slotBody"></tbody>
-        </table>
+        <div class="slot-grid">
+          <table class="slots subtable" id="tableLeft">
+            <thead>
+              <tr><th>時刻</th><th>区分</th><th>内容</th></tr>
+            </thead>
+            <tbody id="slotBodyL"></tbody>
+          </table>
+          <table class="slots subtable" id="tableRight">
+            <thead>
+              <tr><th>時刻</th><th>区分</th><th>内容</th></tr>
+            </thead>
+            <tbody id="slotBodyR"></tbody>
+          </table>
+        </div>
       </div>
 
       <div class="panel">
@@ -98,7 +103,8 @@
       (function () {
         const dateEl = document.getElementById('date');
         const weekdayEl = document.getElementById('weekday');
-        const slotBody = document.getElementById('slotBody');
+        const slotBodyL = document.getElementById('slotBodyL');
+        const slotBodyR = document.getElementById('slotBodyR');
         const sleepEl = document.getElementById('sleep');
         const fatEls = { m: id('fat_m'), n: id('fat_n'), e: id('fat_e') };
         const moodEls = { m: id('mood_m'), n: id('mood_n'), e: id('mood_e') };
@@ -130,25 +136,30 @@
           return v >= 8 ? 'よい' : v >= 4 ? 'ふつう' : 'わるい';
         }
 
-        // Build 48 rows
-        const inputs = [];
-        for (let i = 0; i < 48; i++) {
-          const tr = document.createElement('tr');
-          const td1 = document.createElement('td');
-          td1.textContent = fmt(i);
-          const td2 = document.createElement('td');
-          const inp = document.createElement('input');
-          inp.type = 'text';
-          inp.size = 50;
-          inp.dataset.slot = i;
-          inp.tabIndex = i + 1;
-          inp.placeholder = '作業 / 移動 / 睡眠';
-          td2.appendChild(inp);
-          tr.appendChild(td1);
-          tr.appendChild(td2);
-          slotBody.appendChild(tr);
-          inputs.push(inp);
+        // Build 48 rows (24×2 列) with category select + detail
+        const detailInputs = [];
+        const catSelects = [];
+        const CATS = [
+          ['sleep','睡眠'],['work','仕事'],['study','勉強'],['move','移動'],['meal','食事'],
+          ['exercise','運動'],['house','家事'],['family','家族・ケア'],['rest','休憩'],['other','その他'],
+        ];
+        function buildRow(i){
+          const tr=document.createElement('tr');
+          const td1=document.createElement('td'); td1.textContent=fmt(i);
+          const td2=document.createElement('td');
+          const sel=document.createElement('select'); sel.dataset.slot=i; sel.tabIndex=i+1;
+          for(const [v,lab] of CATS){ const o=document.createElement('option'); o.value=v; o.textContent=lab; sel.appendChild(o); }
+          td2.appendChild(sel);
+          const td3=document.createElement('td');
+          const inp=document.createElement('input'); inp.type='text'; inp.size=40; inp.placeholder='作業 / 移動 / 睡眠'; inp.dataset.slot=i;
+          td3.appendChild(inp);
+          tr.appendChild(td1); tr.appendChild(td2); tr.appendChild(td3);
+          detailInputs[i]=inp; catSelects[i]=sel;
+          sel.addEventListener('change', ()=>{ tr.className='cat-'+(sel.value||'other'); });
+          return tr;
         }
+        for(let i=0;i<24;i++){ slotBodyL.appendChild(buildRow(i)); }
+        for(let i=24;i<48;i++){ slotBodyR.appendChild(buildRow(i)); }
 
         function syncMoodUI() {
           for (const k of ['m', 'n', 'e']) {
@@ -182,11 +193,10 @@
           if (!/^\d{4}-\d{2}-\d{2}$/.test(dateEl.value)) return alert('日付が未指定');
           const r = await fetch(`api/day?date=${dateEl.value}`);
           const j = await r.json();
-          inputs.forEach((inp) => {
-            inp.value = '';
-          });
+          detailInputs.forEach((inp,idx)=>{ if(inp){ inp.value=''; const sel=catSelects[idx]; if(sel){ sel.value='other'; sel.dispatchEvent(new Event('change')); } }});
           (j.activities || []).forEach((a) => {
-            if (inputs[a.slot]) inputs[a.slot].value = a.label || '';
+            if (detailInputs[a.slot]) detailInputs[a.slot].value = a.label || '';
+            if (catSelects[a.slot]) { catSelects[a.slot].value = a.category || 'other'; catSelects[a.slot].dispatchEvent(new Event('change')); }
           });
           sleepEl.value = j.sleep_minutes || 0;
           fatEls.m.value = j.fatigue?.morning || 0;
@@ -206,8 +216,8 @@
             fatigue: { morning: +fatEls.m.value, noon: +fatEls.n.value, night: +fatEls.e.value },
             mood: { morning: +moodEls.m.value, noon: +moodEls.n.value, night: +moodEls.e.value },
             note: noteEl.value,
-            activities: inputs
-              .map((inp, i) => ({ slot: i, label: inp.value.trim() }))
+            activities: detailInputs
+              .map((inp, i) => ({ slot: i, label: inp.value.trim(), category: catSelects[i]?.value || 'other' }))
               .filter((x) => x.label !== ''),
           };
           const r = await fetch('api/day', {

--- a/public/index.html
+++ b/public/index.html
@@ -26,13 +26,21 @@
         <div class="slot-grid">
           <table class="slots subtable" id="tableLeft">
             <thead>
-              <tr><th>時刻</th><th>区分</th><th>内容</th></tr>
+              <tr>
+                <th>時刻</th>
+                <th>区分</th>
+                <th>内容</th>
+              </tr>
             </thead>
             <tbody id="slotBodyL"></tbody>
           </table>
           <table class="slots subtable" id="tableRight">
             <thead>
-              <tr><th>時刻</th><th>区分</th><th>内容</th></tr>
+              <tr>
+                <th>時刻</th>
+                <th>区分</th>
+                <th>内容</th>
+              </tr>
             </thead>
             <tbody id="slotBodyR"></tbody>
           </table>
@@ -140,26 +148,55 @@
         const detailInputs = [];
         const catSelects = [];
         const CATS = [
-          ['sleep','睡眠'],['work','仕事'],['study','勉強'],['move','移動'],['meal','食事'],
-          ['exercise','運動'],['house','家事'],['family','家族・ケア'],['rest','休憩'],['other','その他'],
+          ['sleep', '睡眠'],
+          ['work', '仕事'],
+          ['study', '勉強'],
+          ['move', '移動'],
+          ['meal', '食事'],
+          ['exercise', '運動'],
+          ['house', '家事'],
+          ['family', '家族・ケア'],
+          ['rest', '休憩'],
+          ['other', 'その他'],
         ];
-        function buildRow(i){
-          const tr=document.createElement('tr');
-          const td1=document.createElement('td'); td1.textContent=fmt(i);
-          const td2=document.createElement('td');
-          const sel=document.createElement('select'); sel.dataset.slot=i; sel.tabIndex=i+1;
-          for(const [v,lab] of CATS){ const o=document.createElement('option'); o.value=v; o.textContent=lab; sel.appendChild(o); }
+        function buildRow(i) {
+          const tr = document.createElement('tr');
+          const td1 = document.createElement('td');
+          td1.textContent = fmt(i);
+          const td2 = document.createElement('td');
+          const sel = document.createElement('select');
+          sel.dataset.slot = i;
+          sel.tabIndex = i + 1;
+          for (const [v, lab] of CATS) {
+            const o = document.createElement('option');
+            o.value = v;
+            o.textContent = lab;
+            sel.appendChild(o);
+          }
           td2.appendChild(sel);
-          const td3=document.createElement('td');
-          const inp=document.createElement('input'); inp.type='text'; inp.size=40; inp.placeholder='作業 / 移動 / 睡眠'; inp.dataset.slot=i;
+          const td3 = document.createElement('td');
+          const inp = document.createElement('input');
+          inp.type = 'text';
+          inp.size = 40;
+          inp.placeholder = '作業 / 移動 / 睡眠';
+          inp.dataset.slot = i;
           td3.appendChild(inp);
-          tr.appendChild(td1); tr.appendChild(td2); tr.appendChild(td3);
-          detailInputs[i]=inp; catSelects[i]=sel;
-          sel.addEventListener('change', ()=>{ tr.className='cat-'+(sel.value||'other'); });
+          tr.appendChild(td1);
+          tr.appendChild(td2);
+          tr.appendChild(td3);
+          detailInputs[i] = inp;
+          catSelects[i] = sel;
+          sel.addEventListener('change', () => {
+            tr.className = 'cat-' + (sel.value || 'other');
+          });
           return tr;
         }
-        for(let i=0;i<24;i++){ slotBodyL.appendChild(buildRow(i)); }
-        for(let i=24;i<48;i++){ slotBodyR.appendChild(buildRow(i)); }
+        for (let i = 0; i < 24; i++) {
+          slotBodyL.appendChild(buildRow(i));
+        }
+        for (let i = 24; i < 48; i++) {
+          slotBodyR.appendChild(buildRow(i));
+        }
 
         function syncMoodUI() {
           for (const k of ['m', 'n', 'e']) {
@@ -193,10 +230,22 @@
           if (!/^\d{4}-\d{2}-\d{2}$/.test(dateEl.value)) return alert('日付が未指定');
           const r = await fetch(`api/day?date=${dateEl.value}`);
           const j = await r.json();
-          detailInputs.forEach((inp,idx)=>{ if(inp){ inp.value=''; const sel=catSelects[idx]; if(sel){ sel.value='other'; sel.dispatchEvent(new Event('change')); } }});
+          detailInputs.forEach((inp, idx) => {
+            if (inp) {
+              inp.value = '';
+              const sel = catSelects[idx];
+              if (sel) {
+                sel.value = 'other';
+                sel.dispatchEvent(new Event('change'));
+              }
+            }
+          });
           (j.activities || []).forEach((a) => {
             if (detailInputs[a.slot]) detailInputs[a.slot].value = a.label || '';
-            if (catSelects[a.slot]) { catSelects[a.slot].value = a.category || 'other'; catSelects[a.slot].dispatchEvent(new Event('change')); }
+            if (catSelects[a.slot]) {
+              catSelects[a.slot].value = a.category || 'other';
+              catSelects[a.slot].dispatchEvent(new Event('change'));
+            }
           });
           sleepEl.value = j.sleep_minutes || 0;
           fatEls.m.value = j.fatigue?.morning || 0;
@@ -217,7 +266,11 @@
             mood: { morning: +moodEls.m.value, noon: +moodEls.n.value, night: +moodEls.e.value },
             note: noteEl.value,
             activities: detailInputs
-              .map((inp, i) => ({ slot: i, label: inp.value.trim(), category: catSelects[i]?.value || 'other' }))
+              .map((inp, i) => ({
+                slot: i,
+                label: inp.value.trim(),
+                category: catSelects[i]?.value || 'other',
+              }))
               .filter((x) => x.label !== ''),
           };
           const r = await fetch('api/day', {

--- a/public/style.css
+++ b/public/style.css
@@ -87,16 +87,36 @@ h1 {
 }
 
 /* カテゴリ色（画面用） */
-.cat-sleep { background: #eef6ff; }
-.cat-work { background: #fff0f0; }
-.cat-study { background: #fff8e1; }
-.cat-move { background: #f0fff0; }
-.cat-meal { background: #f5f0ff; }
-.cat-exercise { background: #e8fff7; }
-.cat-house { background: #f4f4f4; }
-.cat-family { background: #fff2e7; }
-.cat-rest { background: #e7f3ff; }
-.cat-other { background: #ffffff; }
+.cat-sleep {
+  background: #eef6ff;
+}
+.cat-work {
+  background: #fff0f0;
+}
+.cat-study {
+  background: #fff8e1;
+}
+.cat-move {
+  background: #f0fff0;
+}
+.cat-meal {
+  background: #f5f0ff;
+}
+.cat-exercise {
+  background: #e8fff7;
+}
+.cat-house {
+  background: #f4f4f4;
+}
+.cat-family {
+  background: #fff2e7;
+}
+.cat-rest {
+  background: #e7f3ff;
+}
+.cat-other {
+  background: #ffffff;
+}
 
 .metrics {
   display: grid;
@@ -189,14 +209,34 @@ footer {
   }
 
   /* 印刷用パターン（モノクロ判別） */
-  .cat-sleep { background: repeating-linear-gradient(90deg, #000 0 0.6px, #fff 0.6px 3px) !important; }
-  .cat-work { background: repeating-linear-gradient(45deg, #000 0 0.6px, #fff 0.6px 3px) !important; }
-  .cat-study { background: repeating-linear-gradient(135deg, #000 0 0.6px, #fff 0.6px 3px) !important; }
-  .cat-move { background: repeating-linear-gradient(0deg, #000 0 0.6px, #fff 0.6px 3px) !important; }
-  .cat-meal { background: repeating-linear-gradient(45deg, #000 0 0.6px, #fff 0.6px 1.8px) !important; }
-  .cat-exercise { background: repeating-linear-gradient(135deg, #000 0 0.6px, #fff 0.6px 1.8px) !important; }
-  .cat-house { background: repeating-linear-gradient(0deg, #000 0 0.9px, #fff 0.9px 4px) !important; }
-  .cat-family { background: repeating-linear-gradient(90deg, #000 0 0.9px, #fff 0.9px 4px) !important; }
-  .cat-rest { background: repeating-linear-gradient(0deg, #000 0 0.6px, #fff 0.6px 6px) !important; }
-  .cat-other { background: #fff !important; }
+  .cat-sleep {
+    background: repeating-linear-gradient(90deg, #000 0 0.6px, #fff 0.6px 3px) !important;
+  }
+  .cat-work {
+    background: repeating-linear-gradient(45deg, #000 0 0.6px, #fff 0.6px 3px) !important;
+  }
+  .cat-study {
+    background: repeating-linear-gradient(135deg, #000 0 0.6px, #fff 0.6px 3px) !important;
+  }
+  .cat-move {
+    background: repeating-linear-gradient(0deg, #000 0 0.6px, #fff 0.6px 3px) !important;
+  }
+  .cat-meal {
+    background: repeating-linear-gradient(45deg, #000 0 0.6px, #fff 0.6px 1.8px) !important;
+  }
+  .cat-exercise {
+    background: repeating-linear-gradient(135deg, #000 0 0.6px, #fff 0.6px 1.8px) !important;
+  }
+  .cat-house {
+    background: repeating-linear-gradient(0deg, #000 0 0.9px, #fff 0.9px 4px) !important;
+  }
+  .cat-family {
+    background: repeating-linear-gradient(90deg, #000 0 0.9px, #fff 0.9px 4px) !important;
+  }
+  .cat-rest {
+    background: repeating-linear-gradient(0deg, #000 0 0.6px, #fff 0.6px 6px) !important;
+  }
+  .cat-other {
+    background: #fff !important;
+  }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -39,7 +39,7 @@ h1 {
 
 .grid {
   display: grid;
-  grid-template-columns: 2fr 1fr;
+  grid-template-columns: 3fr 2fr;
   gap: 12px;
   padding: 0 12px 12px;
 }
@@ -70,6 +70,33 @@ h1 {
   font-size: 12px;
   padding: 3px 2px;
 }
+
+/* 横レイアウト: 24×2 列のスロットテーブル */
+.slot-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.slot-grid .subtable {
+  width: 100%;
+}
+.slot-grid .subtable thead th {
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+}
+
+/* カテゴリ色（画面用） */
+.cat-sleep { background: #eef6ff; }
+.cat-work { background: #fff0f0; }
+.cat-study { background: #fff8e1; }
+.cat-move { background: #f0fff0; }
+.cat-meal { background: #f5f0ff; }
+.cat-exercise { background: #e8fff7; }
+.cat-house { background: #f4f4f4; }
+.cat-family { background: #fff2e7; }
+.cat-rest { background: #e7f3ff; }
+.cat-other { background: #ffffff; }
 
 .metrics {
   display: grid;
@@ -137,7 +164,7 @@ footer {
   .grid {
     gap: 6px;
     padding: 0 6mm 6mm;
-    grid-template-columns: 2fr 1fr;
+    grid-template-columns: 3fr 2fr;
   }
   .panel {
     break-inside: avoid;
@@ -160,4 +187,16 @@ footer {
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }
+
+  /* 印刷用パターン（モノクロ判別） */
+  .cat-sleep { background: repeating-linear-gradient(90deg, #000 0 0.6px, #fff 0.6px 3px) !important; }
+  .cat-work { background: repeating-linear-gradient(45deg, #000 0 0.6px, #fff 0.6px 3px) !important; }
+  .cat-study { background: repeating-linear-gradient(135deg, #000 0 0.6px, #fff 0.6px 3px) !important; }
+  .cat-move { background: repeating-linear-gradient(0deg, #000 0 0.6px, #fff 0.6px 3px) !important; }
+  .cat-meal { background: repeating-linear-gradient(45deg, #000 0 0.6px, #fff 0.6px 1.8px) !important; }
+  .cat-exercise { background: repeating-linear-gradient(135deg, #000 0 0.6px, #fff 0.6px 1.8px) !important; }
+  .cat-house { background: repeating-linear-gradient(0deg, #000 0 0.9px, #fff 0.9px 4px) !important; }
+  .cat-family { background: repeating-linear-gradient(90deg, #000 0 0.9px, #fff 0.9px 4px) !important; }
+  .cat-rest { background: repeating-linear-gradient(0deg, #000 0 0.6px, #fff 0.6px 6px) !important; }
+  .cat-other { background: #fff !important; }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -137,7 +137,11 @@ function createApp(opts = {}) {
         return res.status(400).json({ error: 'duplicate slot', slot: n });
       }
       seen.add(n);
-      normalizedActs.push({ slot: n, label: String(a?.label || ''), category: String(a?.category || '') });
+      normalizedActs.push({
+        slot: n,
+        label: String(a?.label || ''),
+        category: String(a?.category || ''),
+      });
     }
 
     const tx = db.transaction(() => {

--- a/src/db.js
+++ b/src/db.js
@@ -53,9 +53,17 @@ function initDb(dbFile) {
       date        TEXT NOT NULL,
       slot_index  INTEGER NOT NULL,
       label       TEXT DEFAULT '',
+      category    TEXT DEFAULT '',
       PRIMARY KEY(date, slot_index)
     );
   `);
+  // best-effort migration for existing DB: add category if missing
+  try {
+    const cols = db.prepare("PRAGMA table_info(activities)").all();
+    if (!cols.some(c => c.name === 'category')) {
+      db.exec("ALTER TABLE activities ADD COLUMN category TEXT DEFAULT ''");
+    }
+  } catch (_) {}
   return db;
 }
 

--- a/src/db.js
+++ b/src/db.js
@@ -59,8 +59,8 @@ function initDb(dbFile) {
   `);
   // best-effort migration for existing DB: add category if missing
   try {
-    const cols = db.prepare("PRAGMA table_info(activities)").all();
-    if (!cols.some(c => c.name === 'category')) {
+    const cols = db.prepare('PRAGMA table_info(activities)').all();
+    if (!cols.some((c) => c.name === 'category')) {
       db.exec("ALTER TABLE activities ADD COLUMN category TEXT DEFAULT ''");
     }
   } catch (_) {}

--- a/tests/api/day.test.js
+++ b/tests/api/day.test.js
@@ -40,8 +40,8 @@ describe('/api/day', () => {
     const g = await request(app).get('/api/day').query({ date: '2025-09-01' });
     expect(g.status).toBe(200);
     expect(g.body.activities).toEqual([
-      { slot: 0, label: '朝食' },
-      { slot: 3, label: '移動' },
+      { slot: 0, label: '朝食', category: '' },
+      { slot: 3, label: '移動', category: '' },
     ]);
     expect(g.body.sleep_minutes).toBe(300);
     expect(g.body.fatigue).toEqual({ morning: 3, noon: 5, night: 7 });


### PR DESCRIPTION
Epic #29 の実装第一弾。
- DB: activities.category を追加（既存DBはPRAGMAで存在確認の上ALTER）
- API: /api/day の activities に category を返却/受入
- UI: 24×2列のスロット、区分select+詳細input。今日→最初の空欄へフォーカス
- スタイル: 画面は色、印刷はハッチングでカテゴリ可視化（凡例は次PRで追加）
- テスト更新