### PR TITLE
feat(ui): 月次一覧ページ + 日次→『印刷（1月分）』導線

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -310,10 +310,11 @@
         id('btnSave').addEventListener('click', save);
         id('btnSleep').addEventListener('click', autoSleep);
         id('btnPrint').addEventListener('click', () => {
-          // 別ページの印刷用ビューへ（dateクエリ付き）
           const d = document.getElementById('date').value;
-          const q = /^\d{4}-\d{2}-\d{2}$/.test(d) ? `?date=${d}` : '';
-          window.open(`/print.html${q}`, '_blank');
+          const m = /^\d{4}-\d{2}-\d{2}$/.test(d)
+            ? d.slice(0, 7)
+            : new Date().toISOString().slice(0, 7);
+          window.open(`month.html?month=${m}`, '_blank');
         });
 
         // init


### PR DESCRIPTION
月次一覧（/month.html?month=YYYY-MM）を追加し、日次ページの印刷ボタンは同ページを開くように変更。
- 48セル概況／凡例／印刷ボタン、クリックで日次へ