### PR TITLE
feat(ui): 月次グラフ視認性改善（配色3段階＋高さ可変＋日次連携）

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -116,6 +116,16 @@
 
     <script>
       (function () {
+        // 配色パレットの適用（URL > localStorage > 既定: mid）
+        try {
+          const q = new URLSearchParams(location.search);
+          const palQ = (q.get('pal') || '').toLowerCase();
+          const stPal = localStorage.getItem('dailylog.pal') || '';
+          const palette = ['hc','mid','pastel'].includes(palQ) ? palQ : (['hc','mid','pastel'].includes(stPal) ? stPal : 'mid');
+          document.body.classList.toggle('palette-hc', palette === 'hc');
+          document.body.classList.toggle('palette-mid', palette === 'mid');
+          document.body.classList.toggle('palette-pastel', palette === 'pastel');
+        } catch (_) {}
         const dateEl = document.getElementById('date');
         const weekdayEl = document.getElementById('weekday');
         const slotBodyL = document.getElementById('slotBodyL');

--- a/public/month.html
+++ b/public/month.html
@@ -6,6 +6,7 @@
     <title>月次一覧｜生活行動表</title>
     <link rel="stylesheet" href="style.css" />
     <style>
+      :root { --cell-h: 14px; --grid-gap: 2px; --cell-radius: 2px; --cell-border: 0; }
       body { padding: 8px; }
       .head { display:flex; gap:12px; align-items:center; }
       .head h2 { margin: 6px 0; }
@@ -14,24 +15,69 @@
       .box { width: 10px; height: 10px; border:1px solid #333; }
       .monthwrap { margin-top: 8px; display: grid; grid-template-columns: 1fr; gap: 6px; }
       .dayrow { display:grid; grid-template-columns: 74px auto; gap: 6px; align-items:center; }
-      .grid48 { display: grid; grid-template-columns: repeat(24, 1fr); gap: 1px; }
-      .cell { height: 10px; border:1px solid #ccc; }
+      .grid48 { display: grid; grid-template-columns: repeat(24, 1fr); gap: var(--grid-gap); }
+      .cell { height: var(--cell-h); border: var(--cell-border); border-radius: var(--cell-radius); }
       .muted { color:#666; font-size:12px; }
-      @media print { body { padding:0 } .noprint { display:none } }
+      @media print {
+        body { padding:0 }
+        .noprint { display:none }
+        .legend, .dayrow { break-inside: avoid; page-break-inside: avoid; }
+      }
     </style>
   </head>
   <body>
     <div class="head">
       <h2 id="mtitle">月次一覧</h2>
       <div class="legend" id="legend"></div>
+      <label class="noprint" style="display:flex; align-items:center; gap:6px;">
+        サンプル
+        <select id="selSample">
+          <option value="0">実データ</option>
+          <option value="1">サンプル1: 標準勤務日</option>
+          <option value="2">サンプル2: 夜勤日</option>
+          <option value="3">サンプル3: 学習集中日</option>
+          <option value="4">サンプル4: 旅行日</option>
+          <option value="5">サンプル5: 家族・ケア日</option>
+          <option value="6">サンプル6: 回復（休養）日</option>
+        </select>
+      </label>
+      <label class="noprint" style="display:flex; align-items:center; gap:6px;">
+        配色
+        <select id="selPalette">
+          <option value="hc">高コントラスト</option>
+          <option value="mid" selected>ミドル（標準）</option>
+          <option value="pastel">淡色（旧配色）</option>
+        </select>
+      </label>
+      <label class="noprint" style="display:flex; align-items:center; gap:6px;">
+        高さ
+        <select id="selHeight">
+          <option value="10">10px（密）</option>
+          <option value="14" selected>14px（標準）</option>
+          <option value="18">18px（広）</option>
+          <option value="22">22px（特大）</option>
+        </select>
+      </label>
       <button class="noprint" id="btnPrint">印刷</button>
     </div>
-    <div class="muted">各行: 30分×24時間の概況（カテゴリパターン）。クリックで日次ページへ。</div>
+    <div class="muted" id="subtitle">各行: 30分×24時間の概況（カテゴリパターン）。クリックで日次ページへ。</div>
     <div class="monthwrap" id="monthwrap"></div>
     <script>
       (async function(){
         const q = new URLSearchParams(location.search);
         const m = q.get('month') || new Date().toISOString().slice(0,7);
+        const sampleId = parseInt(q.get('sample') || '0', 10) || 0;
+        const palQ = (q.get('pal')||'').toLowerCase();
+        const storedPal = localStorage.getItem('dailylog.pal') || '';
+        const palette = ['hc','mid','pastel'].includes(palQ) ? palQ : (['hc','mid','pastel'].includes(storedPal) ? storedPal : 'mid');
+        document.body.classList.toggle('palette-hc', palette === 'hc');
+        document.body.classList.toggle('palette-mid', palette === 'mid');
+        document.body.classList.toggle('palette-pastel', palette === 'pastel');
+        const hParam = parseInt(q.get('h') || '', 10);
+        const storedH = parseInt(localStorage.getItem('dailylog.cell_h') || '', 10);
+        const hPick = !Number.isNaN(hParam) ? hParam : (!Number.isNaN(storedH) ? storedH : 14);
+        if(hPick >= 8 && hPick <= 28){ document.documentElement.style.setProperty('--cell-h', hPick + 'px'); }
+        const useSample = sampleId > 0;
         document.getElementById('mtitle').textContent = `月次一覧 ${m}`;
         const CATS = [['sleep','睡眠'],['work','仕事'],['study','勉強'],['move','移動'],['meal','食事'],['exercise','運動'],['house','家事'],['family','家族・ケア'],['rest','休憩'],['other','その他']];
         const lg = document.getElementById('legend');
@@ -42,22 +88,166 @@
           const last = new Date(Y, MM, 0).getDate();
           const out=[]; for(let d=1; d<=last; d++){ out.push(`${ym}-${String(d).padStart(2,'0')}`); } return out;
         }
+        function range(a,b){ const out=[]; for(let i=a;i<b;i++) out.push(i); return out; }
+        const slot = (h,m)=> h*2 + (m>=30?1:0);
+        function samplePlanForDay(d, sample){
+          const acts=[]; const push=(start,end,cat,label)=>{ for(let i=start;i<end;i++){ acts.push({slot:i,label,category:cat}); } };
+          const PB=(h1,m1,h2,m2,cat,label)=> push(slot(h1,m1), slot(h2,m2), cat, label);
+          switch(sample){
+            case 1: // 標準勤務日
+              PB(0,0, 6,30, 'sleep','睡眠');
+              PB(6,30, 7,30, 'house','家事');
+              PB(7,30, 9,0,  'move','移動');
+              PB(9,0, 12,0,  'work','仕事');
+              PB(12,0,13,0,  'meal','食事');
+              PB(13,0,17,0,  'work','仕事');
+              PB(17,0,18,30, 'study','勉強');
+              PB(18,30,19,30,'exercise','運動');
+              PB(19,30,21,0, 'family','家族・ケア');
+              PB(21,0, 22,0, 'meal','食事');
+              PB(22,0,23,0,  'rest','休憩');
+              PB(23,0,24,0,  'sleep','睡眠');
+              break;
+            case 2: // 夜勤日
+              PB(0,0, 6,0,   'work','仕事');
+              PB(6,0, 7,0,   'move','移動');
+              PB(7,0, 14,30, 'sleep','睡眠');
+              PB(14,30,15,30,'meal','食事');
+              PB(15,30,17,0, 'house','家事');
+              PB(17,0, 20,0, 'family','家族・ケア');
+              PB(20,0, 21,0, 'meal','食事');
+              PB(21,0, 24,0, 'work','仕事');
+              break;
+            case 3: // 学習集中日
+              PB(0,0, 7,0,   'sleep','睡眠');
+              PB(7,0, 8,0,   'house','家事');
+              PB(8,0, 9,0,   'move','移動');
+              PB(9,0, 12,0,  'study','勉強');
+              PB(12,0,13,0,  'meal','食事');
+              PB(13,0,17,0,  'study','勉強');
+              PB(17,0,18,0,  'exercise','運動');
+              PB(18,0,19,0,  'move','移動');
+              PB(19,0,20,0,  'meal','食事');
+              PB(20,0,22,0,  'study','勉強');
+              PB(22,0,24,0,  'rest','休憩');
+              break;
+            case 4: // 旅行日
+              PB(0,0, 5,0,   'sleep','睡眠');
+              PB(5,0, 6,0,   'house','家事');
+              PB(6,0, 12,0,  'move','移動');
+              PB(12,0,13,0,  'meal','食事');
+              PB(13,0,17,0,  'move','移動');
+              PB(17,0,18,0,  'rest','休憩');
+              PB(18,0,19,0,  'meal','食事');
+              PB(19,0,21,0,  'family','家族・ケア');
+              PB(21,0,24,0,  'sleep','睡眠');
+              break;
+            case 5: // 家族・ケア日
+              PB(0,0, 6,30,  'sleep','睡眠');
+              PB(6,30,8,0,   'house','家事');
+              PB(8,0, 12,0,  'family','家族・ケア');
+              PB(12,0,13,0,  'meal','食事');
+              PB(13,0,16,0,  'family','家族・ケア');
+              PB(16,0,17,0,  'move','移動');
+              PB(17,0,18,0,  'exercise','運動');
+              PB(18,0,20,0,  'family','家族・ケア');
+              PB(20,0,21,0,  'meal','食事');
+              PB(21,0,22,0,  'house','家事');
+              PB(22,0,24,0,  'rest','休憩');
+              break;
+            case 6: // 回復（休養）日
+              PB(0,0, 9,0,   'sleep','睡眠');
+              PB(9,0, 10,0,  'meal','食事');
+              PB(10,0,12,0,  'rest','休憩');
+              PB(12,0,13,0,  'meal','食事');
+              PB(13,0,15,0,  'rest','休憩');
+              PB(15,0,16,0,  'exercise','運動');
+              PB(16,0,18,0,  'rest','休憩');
+              PB(18,0,19,0,  'meal','食事');
+              PB(19,0,24,0,  'sleep','睡眠');
+              break;
+            default:
+              return samplePlanForDay(d, 1);
+          }
+          return acts;
+        }
         const container = document.getElementById('monthwrap');
         for(const d of daysInMonth(m)){
-          const r = await fetch(`api/day?date=${d}`);
-          const j = await r.json();
+          let j;
+          if(useSample){
+            j = { activities: samplePlanForDay(d, sampleId) };
+          } else {
+            const r = await fetch(`api/day?date=${d}`);
+            j = await r.json();
+          }
           const row=document.createElement('div'); row.className='dayrow';
           const label=document.createElement('div'); label.textContent=d; label.className='muted'; row.appendChild(label);
           const grid=document.createElement('div'); grid.className='grid48';
           const bySlot=new Map((j.activities||[]).map(a=>[a.slot,a]));
           for(let i=0;i<48;i++){ const c=document.createElement('div'); c.className='cell'; const a=bySlot.get(i); const cat=(a?.category)||'other'; c.classList.add('cat-'+cat); c.title=String(a?.label||''); grid.appendChild(c);}          
           row.appendChild(grid);
-          row.addEventListener('click', ()=>{ window.open(`./?date=${d}`,'_blank'); });
+          row.addEventListener('click', ()=>{
+            const u = new URL('./', location.href);
+            u.searchParams.set('date', d);
+            u.searchParams.set('pal', palette);
+            window.open(u.toString(), '_blank');
+          });
           container.appendChild(row);
+        }
+        const SAMPLE_META = {
+          1: {t:'標準勤務日', d:'日勤・移動・運動・家族・食事がバランス'},
+          2: {t:'夜勤日', d:'深夜～早朝が仕事、昼間に睡眠'},
+          3: {t:'学習集中日', d:'日中と夜に学習ブロックが長い'},
+          4: {t:'旅行日', d:'移動が長時間を占める'},
+          5: {t:'家族・ケア日', d:'家族・ケアの帯が主'},
+          6: {t:'回復（休養）日', d:'睡眠と休憩が多め、軽い運動'}
+        };
+        const sel = document.getElementById('selSample');
+        sel.value = String(sampleId);
+        sel.addEventListener('change', ()=>{
+          const u = new URL(location.href); u.searchParams.set('sample', sel.value); location.href = u.toString();
+        });
+        const selPal = document.getElementById('selPalette');
+        selPal.value = palette;
+        function applyPalette(p){
+          document.body.classList.toggle('palette-hc', p === 'hc');
+          document.body.classList.toggle('palette-mid', p === 'mid');
+          document.body.classList.toggle('palette-pastel', p === 'pastel');
+          if(p === 'hc'){
+            document.documentElement.style.setProperty('--grid-gap','2px');
+            document.documentElement.style.setProperty('--cell-border','0');
+            document.documentElement.style.setProperty('--cell-radius','2px');
+          } else if(p === 'mid') {
+            document.documentElement.style.setProperty('--grid-gap','2px');
+            document.documentElement.style.setProperty('--cell-border','0');
+            document.documentElement.style.setProperty('--cell-radius','2px');
+          } else {
+            document.documentElement.style.setProperty('--grid-gap','1px');
+            document.documentElement.style.setProperty('--cell-border','1px solid #ccc');
+            document.documentElement.style.setProperty('--cell-radius','0');
+          }
+        }
+        applyPalette(palette);
+        selPal.addEventListener('change', ()=>{
+          applyPalette(selPal.value);
+          localStorage.setItem('dailylog.pal', selPal.value);
+          const u = new URL(location.href); u.searchParams.set('pal', selPal.value); history.replaceState(null,'',u.toString());
+        });
+        const selH = document.getElementById('selHeight');
+        const currentH = getComputedStyle(document.documentElement).getPropertyValue('--cell-h').trim().replace('px','');
+        if(currentH) selH.value = currentH;
+        selH.addEventListener('change', ()=>{
+          document.documentElement.style.setProperty('--cell-h', selH.value + 'px');
+          localStorage.setItem('dailylog.cell_h', selH.value);
+          const u = new URL(location.href); u.searchParams.set('h', selH.value); history.replaceState(null,'',u.toString());
+        });
+        if(useSample){
+          const meta = SAMPLE_META[sampleId];
+          const palLabel = palette === 'hc' ? '高コントラスト' : (palette === 'mid' ? 'ミドル' : '淡色（旧配色）');
+          document.getElementById('subtitle').textContent = `サンプル${sampleId}: ${meta?.t}（${meta?.d}）｜配色: ${palLabel} - DB不要のモック表示`;
         }
         document.getElementById('btnPrint').addEventListener('click', ()=> window.print());
       })();
     </script>
   </body>
   </html>
-

--- a/public/style.css
+++ b/public/style.css
@@ -3,6 +3,28 @@
   --muted: #666;
   --border: #ccc;
   --bg: #fff;
+  /* Graph (month grid) high-contrast palette - Okabe–Ito inspired */
+  --cat-sleep: #56B4E9;    /* sky blue */
+  --cat-work: #D55E00;     /* vermillion */
+  --cat-study: #E69F00;    /* orange */
+  --cat-move: #009E73;     /* bluish green */
+  --cat-meal: #CC79A7;     /* reddish purple */
+  --cat-exercise: #0072B2; /* blue */
+  --cat-house: #7F7F7F;    /* grey */
+  --cat-family: #F0E442;   /* yellow */
+  --cat-rest: #A6761D;     /* brown */
+  --cat-other: #B3B3B3;    /* light grey */
+  /* Medium palette (between pastel and high-contrast) */
+  --cat-sleep-md: #9FD3F2;
+  --cat-work-md: #F2A56F;
+  --cat-study-md: #F4C76A;
+  --cat-move-md: #5CC3A8;
+  --cat-meal-md: #E4A9C8;
+  --cat-exercise-md: #59A3D3;
+  --cat-house-md: #B3B3B3;
+  --cat-family-md: #F6EDA0;
+  --cat-rest-md: #C79B52;
+  --cat-other-md: #D7D7D7;
 }
 * {
   box-sizing: border-box;
@@ -129,6 +151,54 @@ h1 {
   background: #ffffff;
 }
 
+/* 高コントラスト（グラフ専用スコープ） */
+/* 月次グリッドと凡例ボックスのみ強配色にし、日次のテーブル背景は従来の淡色を維持 */
+.palette-hc .grid48 .cell { border: 0 !important; }
+.palette-hc .cat-sleep { background: var(--cat-sleep) !important; }
+.palette-hc .cat-work { background: var(--cat-work) !important; }
+.palette-hc .cat-study { background: var(--cat-study) !important; }
+.palette-hc .cat-move { background: var(--cat-move) !important; }
+.palette-hc .cat-meal { background: var(--cat-meal) !important; }
+.palette-hc .cat-exercise { background: var(--cat-exercise) !important; }
+.palette-hc .cat-house { background: var(--cat-house) !important; }
+.palette-hc .cat-family { background: var(--cat-family) !important; }
+.palette-hc .cat-rest { background: var(--cat-rest) !important; }
+.palette-hc .cat-other { background: var(--cat-other) !important; }
+
+.palette-hc .legend .box.cat-sleep { background: var(--cat-sleep) !important; }
+.palette-hc .legend .box.cat-work { background: var(--cat-work) !important; }
+.palette-hc .legend .box.cat-study { background: var(--cat-study) !important; }
+.palette-hc .legend .box.cat-move { background: var(--cat-move) !important; }
+.palette-hc .legend .box.cat-meal { background: var(--cat-meal) !important; }
+.palette-hc .legend .box.cat-exercise { background: var(--cat-exercise) !important; }
+.palette-hc .legend .box.cat-house { background: var(--cat-house) !important; }
+.palette-hc .legend .box.cat-family { background: var(--cat-family) !important; }
+.palette-hc .legend .box.cat-rest { background: var(--cat-rest) !important; }
+.palette-hc .legend .box.cat-other { background: var(--cat-other) !important; }
+
+/* ミドル配色（中コントラスト） */
+.palette-mid .cat-sleep { background: var(--cat-sleep-md) !important; }
+.palette-mid .cat-work { background: var(--cat-work-md) !important; }
+.palette-mid .cat-study { background: var(--cat-study-md) !important; }
+.palette-mid .cat-move { background: var(--cat-move-md) !important; }
+.palette-mid .cat-meal { background: var(--cat-meal-md) !important; }
+.palette-mid .cat-exercise { background: var(--cat-exercise-md) !important; }
+.palette-mid .cat-house { background: var(--cat-house-md) !important; }
+.palette-mid .cat-family { background: var(--cat-family-md) !important; }
+.palette-mid .cat-rest { background: var(--cat-rest-md) !important; }
+.palette-mid .cat-other { background: var(--cat-other-md) !important; }
+
+.palette-mid .legend .box.cat-sleep { background: var(--cat-sleep-md) !important; }
+.palette-mid .legend .box.cat-work { background: var(--cat-work-md) !important; }
+.palette-mid .legend .box.cat-study { background: var(--cat-study-md) !important; }
+.palette-mid .legend .box.cat-move { background: var(--cat-move-md) !important; }
+.palette-mid .legend .box.cat-meal { background: var(--cat-meal-md) !important; }
+.palette-mid .legend .box.cat-exercise { background: var(--cat-exercise-md) !important; }
+.palette-mid .legend .box.cat-house { background: var(--cat-house-md) !important; }
+.palette-mid .legend .box.cat-family { background: var(--cat-family-md) !important; }
+.palette-mid .legend .box.cat-rest { background: var(--cat-rest-md) !important; }
+.palette-mid .legend .box.cat-other { background: var(--cat-other-md) !important; }
+
 .metrics {
   display: grid;
   gap: 10px;
@@ -248,6 +318,39 @@ footer {
     background: repeating-linear-gradient(0deg, #000 0 0.6px, #fff 0.6px 6px) !important;
   }
   .cat-other {
+    background: #fff !important;
+  }
+
+  /* 月次グラフ（grid48）向け：モノクロ時の判別性をより高める粗めパターンと薄い罫線 */
+  .grid48 .cell { border: 0.2mm solid #000 !important; }
+  .grid48 .cat-sleep {
+    background: repeating-linear-gradient(90deg, #000 0 0.2mm, #fff 0.2mm 1.0mm) !important;
+  }
+  .grid48 .cat-work {
+    background: repeating-linear-gradient(45deg, #000 0 0.25mm, #fff 0.25mm 1.2mm) !important;
+  }
+  .grid48 .cat-study {
+    background: repeating-linear-gradient(135deg, #000 0 0.25mm, #fff 0.25mm 1.2mm) !important;
+  }
+  .grid48 .cat-move {
+    background: repeating-linear-gradient(0deg, #000 0 0.2mm, #fff 0.2mm 1.2mm) !important;
+  }
+  .grid48 .cat-meal {
+    background: repeating-linear-gradient(45deg, #000 0 0.2mm, #fff 0.2mm 0.9mm) !important;
+  }
+  .grid48 .cat-exercise {
+    background: repeating-linear-gradient(135deg, #000 0 0.2mm, #fff 0.2mm 0.9mm) !important;
+  }
+  .grid48 .cat-house {
+    background: repeating-linear-gradient(0deg, #000 0 0.3mm, #fff 0.3mm 1.5mm) !important;
+  }
+  .grid48 .cat-family {
+    background: repeating-linear-gradient(90deg, #000 0 0.3mm, #fff 0.3mm 1.5mm) !important;
+  }
+  .grid48 .cat-rest {
+    background: repeating-linear-gradient(0deg, #000 0 0.25mm, #fff 0.25mm 2mm) !important;
+  }
+  .grid48 .cat-other {
     background: #fff !important;
   }
 }


### PR DESCRIPTION
## 目的 / 背景（必須）
- 月次グラフが淡色で識別しづらく、縦幅も小さく「目に刺さる」印象があったため、配色と密度の調整を可能にする。
- 日次と月次のトーンが一致せず体験が分断される問題を解消する。

関連 Issue: #37

## 変更点（必須）
- 月次（month.html）
  - 配色を3段階に拡張（hc/mid/pastel）。既定はミドル（mid）。
  - セル高さを 10/14/18/22px から選択可能（既定14px）。
  - 設定は localStorage に保存し、URLパラメータ（pal/h）があればそちらを優先。
  - サンプルデータ 1〜6 を追加（見え方確認用）。
  - クリックで日次に遷移する際、選択中の `pal` を引き継ぎ。
- 日次（index.html）
  - `pal`（hc/mid/pastel）を URL / localStorage から読み取り、カテゴリ色を同期。
- 印刷（style.css）
  - 月次のモノクロ印刷を最適化（粗めパターン＋薄い罫線）。

## 動作確認（必須）
- 起動: `node server.js`
- 月次: `http://127.0.0.1:3000/month.html?month=2025-09`
  - 配色=ミドル / 高さ=14px が既定。
  - 配色・高さを変更 → 再読込で前回設定が復元されること。
  - `?sample=1..6` でサンプル切替が機能すること。
- 日次: 月次から任意の日をクリック → `pal` が反映されていること（URLまたは localStorage）。
- 印刷: ブラウザ印刷でパターンと罫線が判別しやすいこと。

## 影響範囲（必須）
- UI/CSS/印刷のみ。DB・APIへの影響なし。

## 受け入れ基準（参考: Issue）
- ミドル＋14pxで主要カテゴリが即時に識別できる。
- 配色（hc/mid/pastel）と高さ（10/14/18/22px）が即時反映・復元される。
- 日次へ配色が連携される。
- モノクロ印刷で凡例と帯のパターンが一致し判別可能。

## 補足
- ロールバック: `pal`指定なし＆localStorageクリアで従来の淡色に戻せます。