### PR TITLE
feat(ops): self-hosted runner 導入スクリプトと運用手順追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ npx vitest -r
 - サービス名: `dailylog.service`、作業ディレクトリ: `/srv/dailylog`。
 - 再起動: `sudo systemctl restart dailylog`、疎通: `curl -u $AUTH_USER:$AUTH_PASS http://127.0.0.1:$PORT/api/health`。
 
+### Self-hosted Runner（デプロイ用）
+
+- ラベル: `dailylog-prod`。ワークフロー `.github/workflows/deploy.yml` は `[self-hosted, dailylog-prod]` を要求。
+- 導入手順（要 Registration Token）:
+  1) サーバに `dailylog` ユーザーを用意し、`/srv` に配置
+  2) `scripts/runner/sudoers_dailylog_runner.example` を参考に sudoers を設定（最小権限）
+  3) `RUNNER_TOKEN=xxxx sudo -u dailylog bash scripts/runner/bootstrap-self-hosted.sh`
+  4) GitHub の Runners に `n100ubuntu-dailylog` が Online で表示されることを確認
+  5) `workflow_dispatch` で「Deploy (production)」を試行
+
+### systemd ユニット例
+
+- `scripts/systemd/dailylog.service.example` を `/etc/systemd/system/dailylog.service` に配置・調整。
+- `sudo systemctl daemon-reload && sudo systemctl enable --now dailylog`。
+
 ## ライセンス
 
 未定（必要に応じて追記）。

--- a/scripts/runner/bootstrap-self-hosted.sh
+++ b/scripts/runner/bootstrap-self-hosted.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GitHub Actions self-hosted runner bootstrapper
+# Target host: Ubuntu (n100ubuntu), run as user `dailylog`
+# Directory: /srv/.runner
+# Labels: dailylog-prod
+# Name: n100ubuntu-dailylog
+#
+# Usage:
+#   RUNNER_TOKEN=xxxx ./bootstrap-self-hosted.sh
+# or
+#   ./bootstrap-self-hosted.sh --token xxxx
+#
+# Notes:
+# - Registration token is ephemeral. Do NOT store long-lived secrets here.
+# - Requires: curl, tar, systemd (for svc.sh), sudo (for service restart in workflow)
+
+REPO_URL="https://github.com/mo9mo9-uwu-mo9mo9/dailylog"
+RUNNER_DIR="/srv/.runner"
+RUNNER_NAME="n100ubuntu-dailylog"
+RUNNER_LABELS="dailylog-prod"
+SVC_USER="dailylog"
+
+TOKEN="${RUNNER_TOKEN:-}"
+if [[ "${1:-}" == "--token" && -n "${2:-}" ]]; then
+  TOKEN="$2"
+fi
+
+if [[ -z "$TOKEN" ]]; then
+  echo "[ERR] Registration token is required. Set RUNNER_TOKEN or pass --token." >&2
+  exit 2
+fi
+
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+
+echo "[INFO] Detecting latest runner binary..."
+API_URL="https://api.github.com/repos/actions/runner/releases/latest"
+ASSET_URL=$(curl -fsSL "$API_URL" | \
+  grep -oE '"browser_download_url":\s*"[^"]+linux-x64-[^"]+\.tar\.gz"' | \
+  head -n1 | cut -d '"' -f4)
+
+if [[ -z "$ASSET_URL" ]]; then
+  echo "[ERR] Failed to resolve runner binary URL." >&2
+  exit 1
+fi
+
+echo "[INFO] Downloading runner: $ASSET_URL"
+curl -fsSL "$ASSET_URL" -o runner.tar.gz
+tar xzf runner.tar.gz
+rm -f runner.tar.gz
+
+echo "[INFO] Configuring runner for $REPO_URL ..."
+./config.sh --url "$REPO_URL" \
+  --token "$TOKEN" \
+  --labels "$RUNNER_LABELS" \
+  --name "$RUNNER_NAME" \
+  --unattended \
+  --ephemeral false
+
+echo "[INFO] Installing as service for user: $SVC_USER"
+./svc.sh install "$SVC_USER"
+./svc.sh start
+
+echo "[OK] Runner installed and started. Verify in GitHub > Settings > Actions > Runners."
+

--- a/scripts/runner/sudoers_dailylog_runner.example
+++ b/scripts/runner/sudoers_dailylog_runner.example
@@ -1,0 +1,6 @@
+# Place as /etc/sudoers.d/dailylog-runner (via visudo -f ...)
+# Grants minimal permission for GitHub Runner to restart/check the service.
+
+Defaults:dailylog !requiretty
+dailylog ALL=(root) NOPASSWD: /usr/bin/systemctl restart dailylog, /usr/bin/systemctl is-active dailylog
+

--- a/scripts/systemd/dailylog.service.example
+++ b/scripts/systemd/dailylog.service.example
@@ -1,0 +1,17 @@
+[Unit]
+Description=DailyLog App
+After=network.target
+
+[Service]
+Type=simple
+User=dailylog
+WorkingDirectory=/srv/dailylog
+Environment=PORT=3002
+Environment=DATA_DIR=/srv/dailylog/data
+ExecStart=/usr/bin/node /srv/dailylog/server.js
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
### 目的 / 背景
- Deploy (production) ワークフロー（.github/workflows/deploy.yml）は `[self-hosted, dailylog-prod]` ラベル付き Runner を要求。
- 本PRは n100ubuntu への self-hosted Runner 導入を円滑にするためのスクリプトと運用手順を追加します。

### 変更点
- `scripts/runner/bootstrap-self-hosted.sh`: ランナー導入スクリプト（/srv/.runner、ユーザー `dailylog`、ラベル `dailylog-prod`、Runner名 `n100ubuntu-dailylog`）。
- `scripts/runner/sudoers_dailylog_runner.example`: 最小権限 sudoers 例（`systemctl restart/is-active dailylog` のみ）。
- `scripts/systemd/dailylog.service.example`: systemd ユニット例（WorkingDirectory=/srv/dailylog, PORT=3002）。
- `README.md`: Self-hosted Runner 導入と systemd 運用手順を追記。

### 導入手順（抜粋）
1. `dailylog` ユーザー作成、`/srv` 構成。
2. `scripts/runner/sudoers_dailylog_runner.example` を参考に sudoers を反映。
3. Registration Token を取得して `RUNNER_TOKEN=xxxx sudo -u dailylog bash scripts/runner/bootstrap-self-hosted.sh` 実行。
4. Runners に `n100ubuntu-dailylog` が Online 表示されることを確認。
5. `workflow_dispatch` で Deploy を実行し疎通確認（200 or 401）。

### 受け入れ基準（AC）
- [ ] Runners に `n100ubuntu-dailylog`（Online, ラベル: `dailylog-prod`）が表示される。
- [ ] Deploy (production) が self-hosted ランナーで成功する。
- [ ] デプロイ後 `/api/health` が `{ok:true}`（認証有効時は 401 を許容）。

### セキュリティ
- Registration Token は一時利用のみ。恒久的な秘密は保存しない。
- sudoers は対象コマンドを限定し最小権限化。

### 関連
Closes #43
