### PR TITLE
chore(lint): 未使用変数の警告を解消

### DIFF
--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 const { initDb, defaultDbPath } = require('../src/db');
-const path = require('path');
 
 const dbPath = defaultDbPath();
 const db = initDb(dbPath);
-const file = db.name || db.memory ? '(memory)' : dbPath;
 console.log(`[db:init] initialized at: ${dbPath}`);
 db.close();

--- a/src/db.js
+++ b/src/db.js
@@ -28,7 +28,7 @@ function openDb(dbFile) {
       db.pragma('journal_mode = WAL');
       db.pragma('synchronous = NORMAL');
     }
-  } catch (_) {
+  } catch {
     // Ignore pragma errors in test environments
   }
   return db;
@@ -63,7 +63,7 @@ function initDb(dbFile) {
     if (!cols.some((c) => c.name === 'category')) {
       db.exec("ALTER TABLE activities ADD COLUMN category TEXT DEFAULT ''");
     }
-  } catch (_) {}
+  } catch {}
   return db;
 }
 


### PR DESCRIPTION
## 目的・背景
ESLint の `no-unused-vars` 警告（4件）を解消し、CI ログのノイズを排除して品質シグナルを明確化します。

## 変更点
- scripts/init-db.js: 未使用の `path` import と未使用変数 `file` を削除
- src/db.js: `catch (_){}` → `catch {}` へ変更（未使用捕捉変数を削除）

## 受け入れ基準
- `npm run lint` 実行で警告 0 件
- `npm test` がグリーン（回帰なし）

## 実行ログ（ローカル, 2025-09-02）
- Lint: OK（警告 0 件）
- Test: 4ファイル / 8テスト すべて成功

関連 Issue: #48
Closes #48
