### PR TITLE
feat(ui): 月次グラフに日次指標（睡眠/疲労/気分/メモ）を表示

### DIFF
--- a/public/month.html
+++ b/public/month.html
@@ -289,11 +289,63 @@
           }
           return acts;
         }
+        function sampleMetricsForDay(sample) {
+          // サンプル用のダミー指標（概ねパターンに沿った値）
+          switch (sample) {
+            case 1: // 標準勤務日
+              return {
+                sleep_minutes: 6 * 60 + 30,
+                fatigue: { morning: 3, noon: 4, night: 5 },
+                mood: { morning: 6, noon: 6, night: 7 },
+                note: 'サンプル: 標準勤務',
+              };
+            case 2: // 夜勤日
+              return {
+                sleep_minutes: 7 * 60 + 30,
+                fatigue: { morning: 4, noon: 5, night: 4 },
+                mood: { morning: 4, noon: 5, night: 6 },
+                note: 'サンプル: 夜勤',
+              };
+            case 3: // 学習集中日
+              return {
+                sleep_minutes: 7 * 60,
+                fatigue: { morning: 2, noon: 3, night: 4 },
+                mood: { morning: 6, noon: 7, night: 7 },
+                note: 'サンプル: 学習メモあり',
+              };
+            case 4: // 旅行日
+              return {
+                sleep_minutes: 5 * 60,
+                fatigue: { morning: 3, noon: 5, night: 6 },
+                mood: { morning: 7, noon: 6, night: 6 },
+                note: 'サンプル: 長距離移動',
+              };
+            case 5: // 家族・ケア日
+              return {
+                sleep_minutes: 6 * 60 + 30,
+                fatigue: { morning: 3, noon: 4, night: 4 },
+                mood: { morning: 7, noon: 7, night: 6 },
+                note: 'サンプル: ケア対応',
+              };
+            case 6: // 回復日
+              return {
+                sleep_minutes: 9 * 60,
+                fatigue: { morning: 1, noon: 2, night: 2 },
+                mood: { morning: 5, noon: 6, night: 6 },
+                note: 'サンプル: 休養',
+              };
+            default:
+              return { sleep_minutes: 0, fatigue: {}, mood: {}, note: '' };
+          }
+        }
         const container = document.getElementById('monthwrap');
         for (const d of daysInMonth(m)) {
           let j;
           if (useSample) {
-            j = { activities: samplePlanForDay(d, sampleId) };
+            j = {
+              activities: samplePlanForDay(d, sampleId),
+              ...sampleMetricsForDay(sampleId),
+            };
           } else {
             const r = await fetch(`api/day?date=${d}`);
             j = await r.json();
@@ -309,27 +361,25 @@
           labelWrap.appendChild(dateEl);
           const metricsEl = document.createElement('div');
           metricsEl.className = 'metrics';
-          if (!useSample) {
-            const mm = Number(j?.sleep_minutes || 0);
-            const f = j?.fatigue || {};
-            const mmm = j?.mood || {};
-            const nt = String(j?.note || '').trim();
-            const parts = [];
-            if (mm > 0) parts.push(`睡${toHM(mm)}`);
-            const fSum = (f.morning | 0) + (f.noon | 0) + (f.night | 0);
-            if (fSum > 0) parts.push(`疲${f.morning | 0}/${f.noon | 0}/${f.night | 0}`);
-            const mSum = (mmm.morning | 0) + (mmm.noon | 0) + (mmm.night | 0);
-            if (mSum > 0) parts.push(`気${mmm.morning | 0}/${mmm.noon | 0}/${mmm.night | 0}`);
-            if (nt.length > 0) parts.push('📝');
-            metricsEl.textContent = parts.join(' ');
-            // ツールチップ用に詳細も付与
-            if (parts.length > 0) {
-              metricsEl.title = `睡眠:${mm > 0 ? toHM(mm) : '-'} / 疲労:${f.morning | 0}/${
-                f.noon | 0
-              }/${f.night | 0} / 気分:${mmm.morning | 0}/${mmm.noon | 0}/${
-                mmm.night | 0
-              }${nt ? ' / メモあり' : ''}`;
-            }
+          const mm = Number(j?.sleep_minutes || 0);
+          const f = j?.fatigue || {};
+          const mmm = j?.mood || {};
+          const nt = String(j?.note || '').trim();
+          const parts = [];
+          if (mm > 0) parts.push(`睡${toHM(mm)}`);
+          const fSum = (f.morning | 0) + (f.noon | 0) + (f.night | 0);
+          if (fSum > 0) parts.push(`疲${f.morning | 0}/${f.noon | 0}/${f.night | 0}`);
+          const mSum = (mmm.morning | 0) + (mmm.noon | 0) + (mmm.night | 0);
+          if (mSum > 0) parts.push(`気${mmm.morning | 0}/${mmm.noon | 0}/${mmm.night | 0}`);
+          if (nt.length > 0) parts.push('📝');
+          metricsEl.textContent = parts.join(' ');
+          // ツールチップ用に詳細も付与
+          if (parts.length > 0) {
+            metricsEl.title = `睡眠:${mm > 0 ? toHM(mm) : '-'} / 疲労:${f.morning | 0}/${
+              f.noon | 0
+            }/${f.night | 0} / 気分:${mmm.morning | 0}/${mmm.noon | 0}/${
+              mmm.night | 0
+            }${nt ? ' / メモあり' : ''}`;
           }
           labelWrap.appendChild(metricsEl);
           row.appendChild(labelWrap);

--- a/public/month.html
+++ b/public/month.html
@@ -48,9 +48,30 @@
       }
       .dayrow {
         display: grid;
-        grid-template-columns: 74px auto;
+        /* 指標表示のためラベル幅を拡張（印刷最適化は別Issue #56で対応） */
+        grid-template-columns: 150px auto;
         gap: 6px;
         align-items: center;
+      }
+      .daylabel {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        height: var(--cell-h);
+        line-height: var(--cell-h);
+        overflow: hidden;
+      }
+      .daylabel .date {
+        font-weight: 600;
+        font-size: 12px;
+        color: #444;
+      }
+      .daylabel .metrics {
+        font-size: 10px;
+        color: #666;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .grid48 {
         display: grid;
@@ -279,10 +300,39 @@
           }
           const row = document.createElement('div');
           row.className = 'dayrow';
-          const label = document.createElement('div');
-          label.textContent = d;
-          label.className = 'muted';
-          row.appendChild(label);
+          // ラベル＋指標（睡眠/疲労/気分/メモ）
+          const labelWrap = document.createElement('div');
+          labelWrap.className = 'daylabel';
+          const dateEl = document.createElement('div');
+          dateEl.className = 'date';
+          dateEl.textContent = d;
+          labelWrap.appendChild(dateEl);
+          const metricsEl = document.createElement('div');
+          metricsEl.className = 'metrics';
+          if (!useSample) {
+            const mm = Number(j?.sleep_minutes || 0);
+            const f = j?.fatigue || {};
+            const mmm = j?.mood || {};
+            const nt = String(j?.note || '').trim();
+            const parts = [];
+            if (mm > 0) parts.push(`睡${toHM(mm)}`);
+            const fSum = (f.morning | 0) + (f.noon | 0) + (f.night | 0);
+            if (fSum > 0) parts.push(`疲${f.morning | 0}/${f.noon | 0}/${f.night | 0}`);
+            const mSum = (mmm.morning | 0) + (mmm.noon | 0) + (mmm.night | 0);
+            if (mSum > 0) parts.push(`気${mmm.morning | 0}/${mmm.noon | 0}/${mmm.night | 0}`);
+            if (nt.length > 0) parts.push('📝');
+            metricsEl.textContent = parts.join(' ');
+            // ツールチップ用に詳細も付与
+            if (parts.length > 0) {
+              metricsEl.title = `睡眠:${mm > 0 ? toHM(mm) : '-'} / 疲労:${f.morning | 0}/${
+                f.noon | 0
+              }/${f.night | 0} / 気分:${mmm.morning | 0}/${mmm.noon | 0}/${
+                mmm.night | 0
+              }${nt ? ' / メモあり' : ''}`;
+            }
+          }
+          labelWrap.appendChild(metricsEl);
+          row.appendChild(labelWrap);
           const grid = document.createElement('div');
           grid.className = 'grid48';
           const bySlot = new Map((j.activities || []).map((a) => [a.slot, a]));
@@ -369,6 +419,13 @@
         }
         document.getElementById('btnPrint').addEventListener('click', () => window.print());
       })();
+
+      // --- helpers ---
+      function toHM(mins) {
+        const h = Math.floor(mins / 60);
+        const m2 = mins % 60;
+        return `${h}:${String(m2).padStart(2, '0')}`;
+      }
     </script>
   </body>
 </html>

--- a/public/month.html
+++ b/public/month.html
@@ -48,8 +48,8 @@
       }
       .dayrow {
         display: grid;
-        /* 指標表示のためラベル幅を拡張（印刷最適化は別Issue #56で対応） */
-        grid-template-columns: 150px auto;
+        /* 指標の可読性向上のためラベル列を広げ、グラフ横幅を抑える */
+        grid-template-columns: 180px auto;
         gap: 6px;
         align-items: center;
       }
@@ -63,11 +63,11 @@
       }
       .daylabel .date {
         font-weight: 600;
-        font-size: 12px;
+        font-size: 12px; /* 日付は2桁表示のため12pxで十分 */
         color: #444;
       }
       .daylabel .metrics {
-        font-size: 10px;
+        font-size: 12px; /* 可読性向上 */
         color: #666;
         white-space: nowrap;
         overflow: hidden;
@@ -98,6 +98,9 @@
         .dayrow {
           break-inside: avoid;
           page-break-inside: avoid;
+        }
+        .daylabel .metrics {
+          font-size: 12px; /* 印刷時も視認性を維持 */
         }
       }
     </style>
@@ -357,7 +360,9 @@
           labelWrap.className = 'daylabel';
           const dateEl = document.createElement('div');
           dateEl.className = 'date';
-          dateEl.textContent = d;
+          // 年月は見出しに出ているため、日付のみ（DD）を表示
+          dateEl.textContent = d.slice(8, 10);
+          dateEl.title = d; // ホバーでフル表示
           labelWrap.appendChild(dateEl);
           const metricsEl = document.createElement('div');
           metricsEl.className = 'metrics';


### PR DESCRIPTION
関連 Issue: #55

## 概要
- 月次一覧（public/month.html）に、各日の日次指標をラベル横へコンパクト表示
- 表示内容: 睡眠(分→H:MM) / 疲労(朝/昼/夜) / 気分(朝/昼/夜) / メモ有無(📝)
- サンプルモードでもダミー指標を表示して確認可能

## 実装
- `.daylabel` に日付(DD)と指標を表示
- 指標フォントサイズを12pxに引き上げ、ラベル列幅を180pxへ拡張
- ツールチップ(title)に詳細表示

## 受け入れ基準
- 実データ月で各日のラベル横に指標が表示される
- 値が未入力/ゼロは非表示（または省略）
- 既存のクリック遷移は維持

Closes #55
