### PR TITLE
feat(ui): 月次一覧を横一列グラフ＋下段メタに再構成（確認用）

### DIFF
--- a/public/month.html
+++ b/public/month.html
@@ -655,8 +655,7 @@
         const tsHolder = document.getElementById('timegrid');
         let sizing;
         if (render === 'svg') {
-          // 後段で1行目の幅を実測し、その値で再描画する
-          sizing = null;
+          sizing = buildTimegridSVG();
         } else {
           buildTimegridCSS();
         }
@@ -685,12 +684,7 @@
           // 上段: グラフ（CSS Grid or SVG）
           let grid;
           if (render === 'svg') {
-            // 1行目で正確な幅を実測し、以降の行と時間スケールに適用
-            sizing = sizing || measureSlot(content);
             const { slot, gap, width } = sizing;
-            if (!document.querySelector('.svg-scale')) {
-              buildTimegridSVG(sizing);
-            }
             const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
             svg.setAttribute('width', String(width));
             svg.setAttribute(

--- a/public/month.html
+++ b/public/month.html
@@ -51,13 +51,10 @@
         grid-template-columns: 1fr;
         gap: 6px;
       }
-      /* 列見出し */
+      /* 列見出し（2カラム: 日付 | 内容） */
       .colhead {
         display: grid;
-        grid-template-columns: var(--col-date) minmax(320px, 1fr) var(--col-metrics) minmax(
-            var(--col-note),
-            1fr
-          );
+        grid-template-columns: var(--col-date) 1fr;
         gap: 6px;
         align-items: center;
         font-size: 12px;
@@ -72,10 +69,7 @@
       /* 時間目盛り（グラフの時間軸） */
       .timescale {
         display: grid;
-        grid-template-columns: var(--col-date) minmax(320px, 1fr) var(--col-metrics) minmax(
-            var(--col-note),
-            1fr
-          );
+        grid-template-columns: var(--col-date) 1fr;
         gap: 6px;
         align-items: center;
         color: #666;
@@ -122,11 +116,8 @@
       }
       .dayrow {
         display: grid;
-        /* auto トラックが縮み過ぎてグラフが0幅になるのを防ぐため minmax を使用 */
-        grid-template-columns: var(--col-date) minmax(320px, 1fr) var(--col-metrics) minmax(
-            var(--col-note),
-            1fr
-          );
+        /* 2カラム: 日付 | 内容（内容は上下2段: グラフ/メタ） */
+        grid-template-columns: var(--col-date) 1fr;
         gap: 6px;
         align-items: center;
         padding: 2px 0;
@@ -145,6 +136,18 @@
         font-size: 12px;
         color: #444;
       }
+      .daycontent {
+        display: grid;
+        grid-template-rows: auto auto;
+        row-gap: 4px;
+        align-items: start;
+      }
+      .meta {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        min-height: 14px;
+      }
       .metrics {
         font-size: 12px;
         color: #333;
@@ -158,6 +161,7 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        flex: 1;
       }
       .grid48 {
         display: grid;
@@ -246,17 +250,13 @@
     </div>
     <div class="colhead" aria-hidden="false">
       <div>日付</div>
-      <div>グラフ（0:00→24:00）</div>
-      <div>指標</div>
-      <div>備考</div>
+      <div>グラフ／指標・備考</div>
     </div>
     <div class="timescale" aria-hidden="false">
       <div></div>
       <div>
         <div class="timegrid" id="timegrid"></div>
       </div>
-      <div></div>
-      <div></div>
     </div>
     <div class="monthwrap" id="monthwrap"></div>
     <script>
@@ -566,6 +566,8 @@
           dateEl.textContent = d.slice(8, 10);
           dateEl.title = d; // フル日付
           row.appendChild(dateEl);
+          const content = document.createElement('div');
+          content.className = 'daycontent';
           const grid = document.createElement('div');
           grid.className = 'grid48';
           const bySlot = new Map((j.activities || []).map((a) => [a.slot, a]));
@@ -578,8 +580,8 @@
             c.title = String(a?.label || '');
             grid.appendChild(c);
           }
-          row.appendChild(grid);
-          // 3列目: 指標
+          content.appendChild(grid);
+          // メタ行: 指標 + 備考
           const metricsEl = document.createElement('div');
           metricsEl.className = 'metrics';
           const mm = Number(j?.sleep_minutes || 0);
@@ -601,13 +603,16 @@
               mmm.night | 0
             }${nt ? ' / メモあり' : ''}`;
           }
-          row.appendChild(metricsEl);
-          // 4列目: 備考（note）
           const noteEl = document.createElement('div');
           noteEl.className = 'note';
           noteEl.textContent = nt;
           noteEl.title = nt;
-          row.appendChild(noteEl);
+          const meta = document.createElement('div');
+          meta.className = 'meta';
+          meta.appendChild(metricsEl);
+          meta.appendChild(noteEl);
+          content.appendChild(meta);
+          row.appendChild(content);
           row.addEventListener('click', () => {
             const u = new URL('./', location.href);
             u.searchParams.set('date', d);

--- a/public/month.html
+++ b/public/month.html
@@ -80,7 +80,8 @@
       }
       .timegrid {
         display: grid;
-        grid-template-columns: repeat(24, 1fr);
+        /* グラフ側と完全一致させるため48列（30分単位）に揃える */
+        grid-template-columns: repeat(48, 1fr);
         column-gap: var(--grid-gap);
         height: 16px; /* 目盛り線の高さを統一 */
         align-items: end;
@@ -90,6 +91,7 @@
         position: relative;
         border-left: 2px solid #777; /* 1時間毎の線: 濃さ/太さを統一して視認性を向上 */
         height: 16px; /* 高さも統一 */
+        width: 0; /* 余計なセル幅をとらず、境界線の左辺に固定 */
       }
       .timegrid .tick.major {
         border-left-color: #777;
@@ -318,6 +320,9 @@
           for (let h = 0; h < 24; h++) {
             const tk = document.createElement('div');
             tk.className = 'tick' + (h % 3 === 0 ? ' major' : '');
+            // 48列グリッドの奇数列(1,3,5,...)に時刻線を配置し、
+            // グラフ(30分×48列)の境界と完全一致させる。
+            tk.style.gridColumn = String(h * 2 + 1);
             const lab = document.createElement('span');
             lab.className = 'lab';
             lab.textContent = String(h).padStart(2, '0') + ':00';

--- a/public/month.html
+++ b/public/month.html
@@ -74,7 +74,7 @@
         align-items: center;
         color: #666;
         font-size: 11px;
-        padding-top: 10px; /* 上側に余白を追加してラベル高さを安定化 */
+        padding-top: 14px; /* 上側の余白を増やし、ラベルと横線の干渉を防止 */
         padding-bottom: 4px; /* 下側にも少し余白 */
       }
       .timegrid {
@@ -87,16 +87,16 @@
       }
       .timegrid .tick {
         position: relative;
-        border-left: 1px solid #999; /* 1時間毎の線: 濃さを統一してやや濃く */
+        border-left: 2px solid #777; /* 1時間毎の線: 濃さ/太さを統一して視認性を向上 */
         height: 16px; /* 高さも統一 */
       }
       .timegrid .tick.major {
-        border-left-color: #999;
+        border-left-color: #777;
         height: 16px;
       }
       .timegrid .tick .lab {
         position: absolute;
-        bottom: calc(100% + 4px); /* 線の上に余白を持たせて配置 */
+        bottom: calc(100% + 6px); /* 線の上で十分な余白を確保 */
         transform: translateX(-50%);
         left: 0;
         font-size: 10px;
@@ -114,7 +114,7 @@
       .timegrid .end-label {
         position: absolute;
         right: 0;
-        bottom: 20px; /* 16px(線高) + 4px(オフセット) */
+        bottom: 22px; /* 16px(線高) + 6px(オフセット) */
         transform: translateX(50%);
         font-size: 11px;
         color: #666;

--- a/public/month.html
+++ b/public/month.html
@@ -74,27 +74,29 @@
         align-items: center;
         color: #666;
         font-size: 11px;
+        padding-top: 10px; /* 上側に余白を追加してラベル高さを安定化 */
+        padding-bottom: 4px; /* 下側にも少し余白 */
       }
       .timegrid {
         display: grid;
         grid-template-columns: repeat(24, 1fr);
         column-gap: var(--grid-gap);
-        height: 26px; /* ラベルを線の上に載せるため余白を確保 */
+        height: 16px; /* 目盛り線の高さを統一 */
         align-items: end;
         position: relative; /* 24:00 境界線とラベルのため */
       }
       .timegrid .tick {
         position: relative;
-        border-left: 1px solid #ddd;
-        height: 12px;
+        border-left: 1px solid #999; /* 1時間毎の線: 濃さを統一してやや濃く */
+        height: 16px; /* 高さも統一 */
       }
       .timegrid .tick.major {
-        border-left-color: #aaa;
-        height: 14px;
+        border-left-color: #999;
+        height: 16px;
       }
       .timegrid .tick .lab {
         position: absolute;
-        bottom: calc(100% + 2px); /* 目盛線の上側に配置 */
+        bottom: calc(100% + 4px); /* 線の上に余白を持たせて配置 */
         transform: translateX(-50%);
         left: 0;
         font-size: 10px;
@@ -112,7 +114,7 @@
       .timegrid .end-label {
         position: absolute;
         right: 0;
-        bottom: 16px; /* 24:00 線の上に表示 */
+        bottom: 20px; /* 16px(線高) + 4px(オフセット) */
         transform: translateX(50%);
         font-size: 11px;
         color: #666;

--- a/public/month.html
+++ b/public/month.html
@@ -348,9 +348,13 @@
           lg.appendChild(dv);
         }
         // --- helpers for rendering modes
-        const GAP_PX_DEFAULT = 2;
+        function cssNumber(v, def) {
+          const n = parseFloat(String(v || '').trim());
+          return Number.isFinite(n) ? n : def;
+        }
         function measureSlot(container) {
-          const gap = GAP_PX_DEFAULT;
+          const root = getComputedStyle(document.documentElement);
+          const gap = cssNumber(root.getPropertyValue('--grid-gap'), 2);
           const full = container.clientWidth || 0;
           const slot = Math.max(1, Math.floor((full - 47 * gap) / 48));
           const width = slot * 48 + 47 * gap;
@@ -393,13 +397,14 @@
           for (let h = 0; h < 24; h++) {
             const x = (h * 2 - 1) * (slot + gap) + slot + gap / 2; // 中央
             const line = document.createElementNS(svg.namespaceURI, 'line');
-            const X = Math.round(x) + 0.5; // ピクセル中心
+            const X = Math.round(x) + (gap % 2 ? 0.5 : 0); // 偶奇で最適なアライメント
             line.setAttribute('x1', String(X));
             line.setAttribute('y1', '10');
             line.setAttribute('x2', String(X));
             line.setAttribute('y2', '26');
             line.setAttribute('stroke', '#777');
-            line.setAttribute('stroke-width', '2');
+            line.setAttribute('stroke-width', String(gap));
+            line.setAttribute('vector-effect', 'non-scaling-stroke');
             gLines.appendChild(line);
             const text = document.createElementNS(svg.namespaceURI, 'text');
             text.setAttribute('x', String(X));
@@ -410,14 +415,15 @@
             svg.appendChild(text);
           }
           // 24:00（右端）
-          const Xend = Math.round(width) + 0.5;
+          const Xend = Math.round(width) + (gap % 2 ? 0.5 : 0);
           const lEnd = document.createElementNS(svg.namespaceURI, 'line');
           lEnd.setAttribute('x1', String(Xend));
           lEnd.setAttribute('y1', '10');
           lEnd.setAttribute('x2', String(Xend));
           lEnd.setAttribute('y2', '26');
           lEnd.setAttribute('stroke', '#777');
-          lEnd.setAttribute('stroke-width', '2');
+          lEnd.setAttribute('stroke-width', String(gap));
+          lEnd.setAttribute('vector-effect', 'non-scaling-stroke');
           svg.appendChild(gLines);
           svg.appendChild(lEnd);
           holder.appendChild(svg);

--- a/public/month.html
+++ b/public/month.html
@@ -172,6 +172,37 @@
         text-overflow: ellipsis;
         flex: 1;
       }
+      /* SVG 塗り（mid/hc/pastel を概ね反映） */
+      .svg-grid .cat-sleep {
+        fill: var(--cat-sleep-md);
+      }
+      .svg-grid .cat-work {
+        fill: var(--cat-work-md);
+      }
+      .svg-grid .cat-study {
+        fill: var(--cat-study-md);
+      }
+      .svg-grid .cat-move {
+        fill: var(--cat-move-md);
+      }
+      .svg-grid .cat-meal {
+        fill: var(--cat-meal-md);
+      }
+      .svg-grid .cat-exercise {
+        fill: var(--cat-exercise-md);
+      }
+      .svg-grid .cat-house {
+        fill: var(--cat-house-md);
+      }
+      .svg-grid .cat-family {
+        fill: var(--cat-family-md);
+      }
+      .svg-grid .cat-rest {
+        fill: var(--cat-rest-md);
+      }
+      .svg-grid .cat-other {
+        fill: var(--cat-other-md);
+      }
       .grid48 {
         display: grid;
         /* 48列=30分単位を横一列に展開（折返し無し） */
@@ -274,6 +305,7 @@
         const q = new URLSearchParams(location.search);
         const m = q.get('month') || new Date().toISOString().slice(0, 7);
         const sampleId = parseInt(q.get('sample') || '0', 10) || 0;
+        const render = (q.get('render') || '').toLowerCase(); // '', 'int', 'svg'
         const palQ = (q.get('pal') || '').toLowerCase();
         const storedPal = localStorage.getItem('dailylog.pal') || '';
         const palette = ['hc', 'mid', 'pastel'].includes(palQ)
@@ -315,14 +347,23 @@
           dv.appendChild(sp);
           lg.appendChild(dv);
         }
-        // 時間目盛り（0..23h, 6時間ごとにラベル）
-        const tg = document.getElementById('timegrid');
-        if (tg) {
+        // --- helpers for rendering modes
+        const GAP_PX_DEFAULT = 2;
+        function measureSlot(container) {
+          const gap = GAP_PX_DEFAULT;
+          const full = container.clientWidth || 0;
+          const slot = Math.max(1, Math.floor((full - 47 * gap) / 48));
+          const width = slot * 48 + 47 * gap;
+          return { slot, gap, width };
+        }
+
+        function buildTimegridCSS() {
+          const tg = document.getElementById('timegrid');
+          if (!tg) return;
+          // 48列CSSグリッド: 境界=奇数列に固定
           for (let h = 0; h < 24; h++) {
             const tk = document.createElement('div');
             tk.className = 'tick' + (h % 3 === 0 ? ' major' : '');
-            // 48列グリッドの奇数列(1,3,5,...)に時刻線を配置し、
-            // グラフ(30分×48列)の境界と完全一致させる。
             tk.style.gridColumn = String(h * 2 + 1);
             const lab = document.createElement('span');
             lab.className = 'lab';
@@ -330,11 +371,57 @@
             tk.appendChild(lab);
             tg.appendChild(tk);
           }
-          // 24:00 ラベル（右端）
           const endLab = document.createElement('span');
           endLab.className = 'end-label';
           endLab.textContent = '24:00';
           tg.appendChild(endLab);
+        }
+
+        function buildTimegridSVG() {
+          const holder = document.getElementById('timegrid');
+          if (!holder) return;
+          const wrap = holder.parentElement; // timescaleの右列
+          const { slot, gap, width } = measureSlot(wrap);
+          holder.innerHTML = '';
+          const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+          svg.setAttribute('width', String(width));
+          svg.setAttribute('height', '26');
+          svg.setAttribute('class', 'svg-scale');
+          svg.setAttribute('style', 'display:block');
+          const gLines = document.createElementNS(svg.namespaceURI, 'g');
+          gLines.setAttribute('shape-rendering', 'crispEdges');
+          for (let h = 0; h < 24; h++) {
+            const x = (h * 2 - 1) * (slot + gap) + slot + gap / 2; // 中央
+            const line = document.createElementNS(svg.namespaceURI, 'line');
+            const X = Math.round(x) + 0.5; // ピクセル中心
+            line.setAttribute('x1', String(X));
+            line.setAttribute('y1', '10');
+            line.setAttribute('x2', String(X));
+            line.setAttribute('y2', '26');
+            line.setAttribute('stroke', '#777');
+            line.setAttribute('stroke-width', '2');
+            gLines.appendChild(line);
+            const text = document.createElementNS(svg.namespaceURI, 'text');
+            text.setAttribute('x', String(X));
+            text.setAttribute('y', '8');
+            text.setAttribute('text-anchor', 'middle');
+            text.setAttribute('font-size', '10');
+            text.textContent = String(h).padStart(2, '0') + ':00';
+            svg.appendChild(text);
+          }
+          // 24:00（右端）
+          const Xend = Math.round(width) + 0.5;
+          const lEnd = document.createElementNS(svg.namespaceURI, 'line');
+          lEnd.setAttribute('x1', String(Xend));
+          lEnd.setAttribute('y1', '10');
+          lEnd.setAttribute('x2', String(Xend));
+          lEnd.setAttribute('y2', '26');
+          lEnd.setAttribute('stroke', '#777');
+          lEnd.setAttribute('stroke-width', '2');
+          svg.appendChild(gLines);
+          svg.appendChild(lEnd);
+          holder.appendChild(svg);
+          return { slot, gap, width };
         }
 
         function daysInMonth(ym) {
@@ -558,7 +645,15 @@
           }
         }
         const container = document.getElementById('monthwrap');
-        for (const d of daysInMonth(m)) {
+        const tsHolder = document.getElementById('timegrid');
+        let sizing;
+        if (render === 'svg') {
+          sizing = buildTimegridSVG();
+        } else {
+          buildTimegridCSS();
+        }
+        const days = daysInMonth(m);
+        for (const d of days) {
           let j;
           if (useSample) {
             j = {
@@ -579,18 +674,50 @@
           row.appendChild(dateEl);
           const content = document.createElement('div');
           content.className = 'daycontent';
-          const grid = document.createElement('div');
-          grid.className = 'grid48';
-          const bySlot = new Map((j.activities || []).map((a) => [a.slot, a]));
-          for (let i = 0; i < 48; i++) {
-            const c = document.createElement('div');
-            c.className = 'cell';
-            const a = bySlot.get(i);
-            const cat = a?.category || 'other';
-            c.classList.add('cat-' + cat);
-            c.title = String(a?.label || '');
-            grid.appendChild(c);
+          // 上段: グラフ（CSS Grid or SVG）
+          let grid;
+          if (render === 'svg') {
+            const { slot, gap, width } = sizing || buildTimegridSVG();
+            const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            svg.setAttribute('width', String(width));
+            svg.setAttribute(
+              'height',
+              String(
+                parseInt(getComputedStyle(document.documentElement).getPropertyValue('--cell-h')) ||
+                  14
+              )
+            );
+            svg.setAttribute('class', 'svg-grid');
+            const bySlot = new Map((j.activities || []).map((a) => [a.slot, a]));
+            for (let i = 0; i < 48; i++) {
+              const a = bySlot.get(i);
+              const rect = document.createElementNS(svg.namespaceURI, 'rect');
+              const x = i * (slot + gap);
+              rect.setAttribute('x', String(x));
+              rect.setAttribute('y', '0');
+              rect.setAttribute('width', String(slot));
+              rect.setAttribute('height', '100%');
+              const cat = a?.category || 'other';
+              rect.setAttribute('class', 'cat-' + cat);
+              rect.setAttribute('data-title', String(a?.label || ''));
+              svg.appendChild(rect);
+            }
+            grid = svg;
+          } else {
+            grid = document.createElement('div');
+            grid.className = 'grid48';
+            const bySlot = new Map((j.activities || []).map((a) => [a.slot, a]));
+            for (let i = 0; i < 48; i++) {
+              const c = document.createElement('div');
+              c.className = 'cell';
+              const a = bySlot.get(i);
+              const cat = a?.category || 'other';
+              c.classList.add('cat-' + cat);
+              c.title = String(a?.label || '');
+              grid.appendChild(c);
+            }
           }
+          const bySlot = new Map((j.activities || []).map((a) => [a.slot, a]));
           content.appendChild(grid);
           // メタ行: 指標 + 備考
           const metricsEl = document.createElement('div');

--- a/public/month.html
+++ b/public/month.html
@@ -74,8 +74,9 @@
         align-items: center;
         color: #666;
         font-size: 11px;
-        padding-top: 14px; /* 上側の余白を増やし、ラベルと横線の干渉を防止 */
+        padding-top: 18px; /* 上側の余白をさらに増やし、ヘッダ線と重ならないように */
         padding-bottom: 4px; /* 下側にも少し余白 */
+        margin-top: 6px; /* 見出しの下線との視覚的距離を確保 */
       }
       .timegrid {
         display: grid;
@@ -96,7 +97,7 @@
       }
       .timegrid .tick .lab {
         position: absolute;
-        bottom: calc(100% + 6px); /* 線の上で十分な余白を確保 */
+        bottom: calc(100% + 8px); /* 線の上で十分な余白を確保（被り防止） */
         transform: translateX(-50%);
         left: 0;
         font-size: 10px;
@@ -108,13 +109,13 @@
         position: absolute;
         right: 0;
         bottom: 0;
-        border-left: 1px solid #aaa; /* 24:00 境界線 */
-        height: 14px;
+        border-left: 2px solid #777; /* 24:00 境界線も1時間線と統一 */
+        height: 16px;
       }
       .timegrid .end-label {
         position: absolute;
         right: 0;
-        bottom: 22px; /* 16px(線高) + 6px(オフセット) */
+        bottom: 24px; /* 16px(線高) + 8px(オフセット) */
         transform: translateX(50%);
         font-size: 11px;
         color: #666;

--- a/public/month.html
+++ b/public/month.html
@@ -381,11 +381,12 @@
           tg.appendChild(endLab);
         }
 
-        function buildTimegridSVG() {
+        function buildTimegridSVG(sizingOverride) {
           const holder = document.getElementById('timegrid');
           if (!holder) return;
           const wrap = holder.parentElement; // timescaleの右列
-          const { slot, gap, width } = measureSlot(wrap);
+          const base = sizingOverride || measureSlot(wrap);
+          const { slot, gap, width } = base;
           holder.innerHTML = '';
           const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
           svg.setAttribute('width', String(width));
@@ -654,7 +655,8 @@
         const tsHolder = document.getElementById('timegrid');
         let sizing;
         if (render === 'svg') {
-          sizing = buildTimegridSVG();
+          // 後段で1行目の幅を実測し、その値で再描画する
+          sizing = null;
         } else {
           buildTimegridCSS();
         }
@@ -683,7 +685,12 @@
           // 上段: グラフ（CSS Grid or SVG）
           let grid;
           if (render === 'svg') {
-            const { slot, gap, width } = sizing || buildTimegridSVG();
+            // 1行目で正確な幅を実測し、以降の行と時間スケールに適用
+            sizing = sizing || measureSlot(content);
+            const { slot, gap, width } = sizing;
+            if (!document.querySelector('.svg-scale')) {
+              buildTimegridSVG(sizing);
+            }
             const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
             svg.setAttribute('width', String(width));
             svg.setAttribute(

--- a/public/month.html
+++ b/public/month.html
@@ -92,6 +92,7 @@
         border-left: 2px solid #777; /* 1時間毎の線: 濃さ/太さを統一して視認性を向上 */
         height: 16px; /* 高さも統一 */
         width: 0; /* 余計なセル幅をとらず、境界線の左辺に固定 */
+        left: calc(var(--grid-gap) / -2); /* ギャップの中心に線が来るよう半分だけ左にシフト */
       }
       .timegrid .tick.major {
         border-left-color: #777;

--- a/public/month.html
+++ b/public/month.html
@@ -165,7 +165,8 @@
       }
       .grid48 {
         display: grid;
-        grid-template-columns: repeat(24, 1fr);
+        /* 48列=30分単位を横一列に展開（折返し無し） */
+        grid-template-columns: repeat(48, 1fr);
         gap: var(--grid-gap);
       }
       .cell {

--- a/public/month.html
+++ b/public/month.html
@@ -79,7 +79,7 @@
         display: grid;
         grid-template-columns: repeat(24, 1fr);
         column-gap: var(--grid-gap);
-        height: 16px;
+        height: 26px; /* ラベルを線の上に載せるため余白を確保 */
         align-items: end;
         position: relative; /* 24:00 境界線とラベルのため */
       }
@@ -94,7 +94,7 @@
       }
       .timegrid .tick .lab {
         position: absolute;
-        bottom: 0;
+        bottom: calc(100% + 2px); /* 目盛線の上側に配置 */
         transform: translateX(-50%);
         left: 0;
         font-size: 10px;
@@ -112,7 +112,7 @@
       .timegrid .end-label {
         position: absolute;
         right: 0;
-        bottom: 0;
+        bottom: 16px; /* 24:00 線の上に表示 */
         transform: translateX(50%);
         font-size: 11px;
         color: #666;

--- a/public/month.html
+++ b/public/month.html
@@ -97,6 +97,9 @@
         bottom: 0;
         transform: translateX(-50%);
         left: 0;
+        font-size: 10px;
+        white-space: nowrap;
+        pointer-events: none;
       }
       .timegrid::after {
         content: '';
@@ -311,13 +314,11 @@
         if (tg) {
           for (let h = 0; h < 24; h++) {
             const tk = document.createElement('div');
-            tk.className = 'tick' + (h % 6 === 0 ? ' major' : '');
-            if (h % 6 === 0) {
-              const lab = document.createElement('span');
-              lab.className = 'lab';
-              lab.textContent = String(h).padStart(2, '0') + ':00';
-              tk.appendChild(lab);
-            }
+            tk.className = 'tick' + (h % 3 === 0 ? ' major' : '');
+            const lab = document.createElement('span');
+            lab.className = 'lab';
+            lab.textContent = String(h).padStart(2, '0') + ':00';
+            tk.appendChild(lab);
             tg.appendChild(tk);
           }
           // 24:00 ラベル（右端）


### PR DESCRIPTION
関連 Issue: #72

## 概要
- 月次一覧（画面確認用）を、各日=横一列グラフの直下に「指標+備考」を置く2段構成に変更。

## 変更点
- 行レイアウト: [日付 | (上)グラフ / (下)指標+備考]
- 列見出し/時間スケール: 2カラム対応（左:日付, 右:時間スケール）
- DOM: `.daycontent` と `.meta` を追加して構造を簡素化

## 受け入れ基準
- 各日のグラフが1段に並び、直下に指標+備考が表示される
- 24:00明示・時間方向の明示は維持
- PC/モバイルで崩れない
- 印刷ページ（month_print.html）に影響なし

プレビュー:
- /month.html?month=2025-09&sample=5&pal=mid&h=14