### PR TITLE
fix(ui-svg): 月次時間軸の最終版を反映（中央合わせ/可読性改善）

### DIFF
--- a/public/month.html
+++ b/public/month.html
@@ -123,6 +123,9 @@
         font-size: 11px;
         color: #666;
       }
+      .svg-scale text {
+        font-variant-numeric: tabular-nums;
+      }
       .dayrow {
         display: grid;
         /* 2カラム: 日付 | 内容（内容は上下2段: グラフ/メタ） */
@@ -305,7 +308,7 @@
         const q = new URLSearchParams(location.search);
         const m = q.get('month') || new Date().toISOString().slice(0, 7);
         const sampleId = parseInt(q.get('sample') || '0', 10) || 0;
-        const render = (q.get('render') || '').toLowerCase(); // '', 'int', 'svg'
+        const render = (q.get('render') || 'svg').toLowerCase(); // default svg
         const palQ = (q.get('pal') || '').toLowerCase();
         const storedPal = localStorage.getItem('dailylog.pal') || '';
         const palette = ['hc', 'mid', 'pastel'].includes(palQ)
@@ -361,6 +364,21 @@
           return { slot, gap, width };
         }
 
+        async function waitForSizing() {
+          const holder = document.getElementById('timegrid');
+          const wrap = holder?.parentElement || document.body;
+          // 最大5フレーム待ってレイアウトを安定させる
+          for (let i = 0; i < 5; i++) {
+            const s = measureSlot(wrap);
+            if (s.width > 48) return s;
+            await new Promise((r) => requestAnimationFrame(() => r()));
+          }
+          // フォールバック: monthwrap 幅で計測
+          const mw = document.getElementById('monthwrap');
+          const fb = measureSlot(mw || wrap);
+          return fb.width > 48 ? fb : { slot: 16, gap: 2, width: 16 * 48 + 2 * 47 };
+        }
+
         function buildTimegridCSS() {
           const tg = document.getElementById('timegrid');
           if (!tg) return;
@@ -381,6 +399,32 @@
           tg.appendChild(endLab);
         }
 
+        function drawHourLabel(svg, X, hour, y = 8, margin = 3) {
+          const ns = svg.namespaceURI;
+          const h = String(hour).padStart(2, '0');
+          const left = document.createElementNS(ns, 'text');
+          left.setAttribute('x', String(X - margin));
+          left.setAttribute('y', String(y));
+          left.setAttribute('text-anchor', 'end');
+          left.setAttribute('font-size', '10');
+          left.textContent = h;
+          const colon = document.createElementNS(ns, 'text');
+          colon.setAttribute('x', String(X));
+          colon.setAttribute('y', String(y));
+          colon.setAttribute('text-anchor', 'middle');
+          colon.setAttribute('font-size', '10');
+          colon.textContent = ':';
+          const right = document.createElementNS(ns, 'text');
+          right.setAttribute('x', String(X + margin));
+          right.setAttribute('y', String(y));
+          right.setAttribute('text-anchor', 'start');
+          right.setAttribute('font-size', '10');
+          right.textContent = '00';
+          svg.appendChild(left);
+          svg.appendChild(colon);
+          svg.appendChild(right);
+        }
+
         function buildTimegridSVG(sizingOverride) {
           const holder = document.getElementById('timegrid');
           if (!holder) return;
@@ -392,41 +436,44 @@
           svg.setAttribute('width', String(width));
           svg.setAttribute('height', '26');
           svg.setAttribute('class', 'svg-scale');
-          svg.setAttribute('style', 'display:block');
+          svg.setAttribute('style', 'display:block; overflow:visible');
+          holder.classList.add('svg-mode');
           const gLines = document.createElementNS(svg.namespaceURI, 'g');
           gLines.setAttribute('shape-rendering', 'crispEdges');
+          const strokeColor = '#555';
+          const strokeW = 1; // 細く濃く
           for (let h = 0; h < 24; h++) {
-            const x = (h * 2 - 1) * (slot + gap) + slot + gap / 2; // 中央
+            const rawX = h === 0 ? 0 : (h * 2 - 1) * (slot + gap) + slot + gap / 2; // 中央 or 先頭
+            // 幾何学的中心が整数なら整数ピクセルに、
+            // 小数なら 0.5px オフセットで crisp に描画
+            const isInt = Math.abs(rawX - Math.round(rawX)) < 1e-3;
+            const X = isInt ? Math.round(rawX) : Math.round(rawX) + 0.5;
             const line = document.createElementNS(svg.namespaceURI, 'line');
-            const X = Math.round(x) + (gap % 2 ? 0.5 : 0); // 偶奇で最適なアライメント
             line.setAttribute('x1', String(X));
             line.setAttribute('y1', '10');
             line.setAttribute('x2', String(X));
             line.setAttribute('y2', '26');
-            line.setAttribute('stroke', '#777');
-            line.setAttribute('stroke-width', String(gap));
+            line.setAttribute('stroke', strokeColor);
+            line.setAttribute('stroke-width', String(strokeW));
+            line.setAttribute('stroke-linecap', 'square');
             line.setAttribute('vector-effect', 'non-scaling-stroke');
             gLines.appendChild(line);
-            const text = document.createElementNS(svg.namespaceURI, 'text');
-            text.setAttribute('x', String(X));
-            text.setAttribute('y', '8');
-            text.setAttribute('text-anchor', 'middle');
-            text.setAttribute('font-size', '10');
-            text.textContent = String(h).padStart(2, '0') + ':00';
-            svg.appendChild(text);
+            drawHourLabel(svg, X, h);
           }
           // 24:00（右端）
-          const Xend = Math.round(width) + (gap % 2 ? 0.5 : 0);
+          const Xend = Math.round(width) + (strokeW % 2 ? 0.5 : 0);
           const lEnd = document.createElementNS(svg.namespaceURI, 'line');
           lEnd.setAttribute('x1', String(Xend));
           lEnd.setAttribute('y1', '10');
           lEnd.setAttribute('x2', String(Xend));
           lEnd.setAttribute('y2', '26');
-          lEnd.setAttribute('stroke', '#777');
-          lEnd.setAttribute('stroke-width', String(gap));
+          lEnd.setAttribute('stroke', strokeColor);
+          lEnd.setAttribute('stroke-width', String(strokeW));
+          lEnd.setAttribute('stroke-linecap', 'square');
           lEnd.setAttribute('vector-effect', 'non-scaling-stroke');
           svg.appendChild(gLines);
           svg.appendChild(lEnd);
+          drawHourLabel(svg, Xend, 24);
           holder.appendChild(svg);
           return { slot, gap, width };
         }
@@ -655,7 +702,8 @@
         const tsHolder = document.getElementById('timegrid');
         let sizing;
         if (render === 'svg') {
-          sizing = buildTimegridSVG();
+          sizing = await waitForSizing();
+          buildTimegridSVG(sizing);
         } else {
           buildTimegridCSS();
         }


### PR DESCRIPTION
関連 Issue: #72

- コロン中心ラベル（余白3px）と中央判定の整数/0.5pxルールを適用
- 00:00/24:00の表示を安定化、初期白画面の対策
- 本番の表示崩れを解消するための month.html 反映PR（docsの混在を避け、最小差分）