### PR TITLE
infra(reboot): n100サーバをJST 03:00に自動再起動するWorkflowを追加

### DIFF
--- a/.github/workflows/reboot-n100.yml
+++ b/.github/workflows/reboot-n100.yml
@@ -1,0 +1,27 @@
+name: Reboot (n100 server)
+
+on:
+  schedule:
+    # JST 03:00 = UTC 18:00 (前日)
+    - cron: '0 18 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: reboot-n100
+  cancel-in-progress: false
+
+jobs:
+  reboot:
+    runs-on: [self-hosted, dailylog-prod]
+    steps:
+      - name: Echo schedule and host
+        run: |
+          set -euxo pipefail
+          echo "Now (UTC): $(date -u)"
+          echo "Now (local): $(date)"
+          uname -a || true
+      - name: Reboot host (JST 03:00 daily)
+        run: |
+          echo "Rebooting n100 server via systemd..."
+          sudo /sbin/reboot
+


### PR DESCRIPTION
背景
- 本番n100を毎朝03:00(JST)に再起動したい要望。
方針
- self-hosted runner (dailylog-prod) 上で GitHub Actions のscheduleを使用。UTC 18:00 = JST 03:00。
- 手動実行 (workflow_dispatch) も可能。
注意
- rebootによりジョブは途中でRunnerが落ちるため、Actions上のステータスは"cancelled"相当になる場合があります（挙動としては問題なし）。