### PR TITLE
ci: 自動セルフレビュー（A案）を追加

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,0 +1,34 @@
+name: CI (push)
+
+on:
+  push:
+    branches: [main, 'feat/**', 'fix/**', 'chore/**', 'ci/**']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm install --no-audit --no-fund
+
+      - name: Lint
+        run: npx --yes eslint -c eslint.config.mjs . --ext js
+
+      - name: Format (check only)
+        run: npm run format:check
+
+      - name: Test
+        run: npm test -- --run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,40 @@ jobs:
 
       - name: Test
         run: npm test -- --run
+
+  auto-self-review:
+    name: Auto Self Review (A)
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Mark checkboxes in PR body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.issue.number;
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+            let body = pr.body || '';
+
+            const original = body;
+            // A案: 自動でONにするのは「CI 緑（必須）」「npm install 済み」のみ
+            const rules = [
+              { re: /- \[ \]\s*CI\s*緑（必須）/u, to: '- [x] CI 緑（必須）' },
+              { re: /- \[ \]\s*`?npm install`?\s*済み/u, to: '- [x] `npm install` 済み' },
+            ];
+            for (const r of rules) {
+              body = body.replace(r.re, r.to);
+            }
+
+            if (body !== original) {
+              await github.rest.pulls.update({ owner, repo, pull_number, body });
+              core.notice('PR本文の「動作確認（必須）」の一部チェックを自動ONにしました。');
+            } else {
+              core.notice('更新不要（チェック済み、または該当項目なし）。');
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
-name: CI (lint & test)
-
-# NOTE: ブランチ更新時の安定実行のための微修正（再実行トリガ）
+name: CI (PR)
 
 on:
-  push:
-    branches: [main, 'feat/**', 'fix/**', 'chore/**', 'ci/**']
   pull_request:
     branches: [main]
 
@@ -41,7 +37,7 @@ jobs:
 
   auto-self-review:
     name: Auto Self Review (A)
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
関連 Issue: #79

## 概要
- 非ドラフトPRで `build` 成功後、PR本文の「動作確認（必須）」内の
  - [x] CI 緑（必須）
  - [x] `npm install` 済み
  を自動チェックします。

## 方針
- `.github/workflows/ci.yml` に `auto-self-review` ジョブを追加。`needs: build`。
- `pull-requests: write` 権限で本文を `actions/github-script` から更新。

## 受け入れ基準
- 上記2項目のみが自動で `[x]` になること（他項目は変更しない）。
- 冪等であること（既に `[x]` の場合は無変更）。

## セルフレビュー（作成者・必須）
- [ ] 受け入れ基準を満たす
- [ ] 影響範囲の自己レビュー

## 補足
- 本PRで挙動を確認後、必要なら対象項目の拡張を別Issueで検討します。
\n---\n追記: CI を PR/push で分離しました。\n- CI (PR): build + Auto Self Review (A)\n- CI (push): build のみ\n関連 Issue: #79