### PR TITLE
ci(alerts): Deploy失敗時に通知Issue作成・成功時に自動クローズ

### DIFF
--- a/.github/workflows/deploy-alert.yml
+++ b/.github/workflows/deploy-alert.yml
@@ -2,7 +2,7 @@ name: Deploy Alerts
 
 on:
   workflow_run:
-    workflows: ["Deploy (production)"]
+    workflows: ['Deploy (production)']
     types: [completed]
 
 permissions:
@@ -70,4 +70,3 @@ jobs:
             } else {
               core.info('No open failure issue to close.');
             }
-

--- a/.github/workflows/deploy-alert.yml
+++ b/.github/workflows/deploy-alert.yml
@@ -1,0 +1,73 @@
+name: Deploy Alerts
+
+on:
+  workflow_run:
+    workflows: ["Deploy (production)"]
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  on-failure:
+    if: ${{ github.event.workflow_run.conclusion != 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or update failure Issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const wr = context.payload.workflow_run;
+            const title = `infra: Deploy (production) 失敗通知`;
+            const labels = ["type:infra", "priority:P0"]; // P0: 要即時対応
+            const assignees = ["mo9mo9-uwu-mo9mo9"];
+
+            // 探す: タイトル一致のOpen Issue
+            const { data: issues } = await github.rest.issues.listForRepo({ owner, repo, state: 'open', per_page: 100, labels: labels.join(',') });
+            let found = issues.find(i => i.title === title);
+
+            const body = [
+              `デプロイが失敗しました。対応お願いします。`,
+              ``,
+              `- 結果: ${wr.conclusion}`,
+              `- Run: ${wr.html_url}`,
+              `- Branch: ${wr.head_branch}`,
+              `- SHA: ${wr.head_sha}`,
+              `- 発生: ${wr.updated_at}`,
+            ].join('\n');
+
+            if (!found) {
+              const created = await github.rest.issues.create({ owner, repo, title, body, labels, assignees });
+              core.info(`Created issue #${created.data.number}`);
+            } else {
+              await github.rest.issues.update({ owner, repo, issue_number: found.number, state: 'open', assignees });
+              await github.rest.issues.createComment({ owner, repo, issue_number: found.number, body });
+              core.info(`Updated issue #${found.number}`);
+            }
+
+  on-success:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close failure Issue if exists
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = `infra: Deploy (production) 失敗通知`;
+            const { data: issues } = await github.rest.issues.listForRepo({ owner, repo, state: 'open', per_page: 100, labels: 'type:infra,priority:P0' });
+            const found = issues.find(i => i.title === title);
+            if (found) {
+              await github.rest.issues.createComment({ owner, repo, issue_number: found.number, body: '復旧: 直近のデプロイが成功しました。Issueをクローズします。' });
+              await github.rest.issues.update({ owner, repo, issue_number: found.number, state: 'closed' });
+              core.info(`Closed issue #${found.number}`);
+            } else {
+              core.info('No open failure issue to close.');
+            }
+


### PR DESCRIPTION
関連 Issue: #95

概要:
- "Deploy (production)" の完了をhookし、失敗時に通知Issueを自動作成/追記、成功時にOpenな通知Issueを自動クローズします。

詳細:
- 失敗: タイトル固定 `infra: Deploy (production) 失敗通知`、labels=`type:infra,priority:P0`、assignees=`@mo9mo9-uwu-mo9mo9`
- 成功: 上記IssueがOpenならクローズ（コメント: 復旧）

受け入れ基準:
- Deploy失敗でIssue起票/追記、成功で自動クローズ。

影響範囲:
- CI/Issues のみ（アプリ・本番無影響）

ロールバック:
- `.github/workflows/deploy-alert.yml` を削除/無効化で即時戻し可能。