### PR TITLE
refactor(ui): 月次データ取得を /api/month 優先に変更（/api/day へフォールバック）

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,44 @@ npx vitest -r
 
 ## 想定ディレクトリ
 
+````
+
+## API 概要
+
+- `GET /api/health` → `{ ok: true }`（Basic認証有効時は未認証で 401）
+- `GET /api/day?date=YYYY-MM-DD` → 単日データ
+- `POST /api/day` → 単日データの作成/更新
+- `GET /api/export?month=YYYY-MM` → 月次CSV（ヘッダ + 48行×日数）
+- `GET /api/month?month=YYYY-MM` → 月次JSON集約（画面最適化用）
+
+### /api/month 仕様（簡易）
+
+- リクエスト: `GET /api/month?month=2025-09`
+- レスポンス例（抜粋）:
+
+```json
+{
+  "month": "2025-09",
+  "days": [
+    {
+      "date": "2025-09-01",
+      "sleep_minutes": 300,
+      "fatigue": { "morning": 3, "noon": 4, "night": 5 },
+      "mood": { "morning": 6, "noon": 7, "night": 8 },
+      "note": "...",
+      "activities": [ { "slot": 0, "category": "sleep", "label": "睡眠" } ]
+    }
+  ]
+}
+````
+
+- 異常: `month` が `YYYY-MM` でない場合は 400。
+- 備考: 月内の全日を昇順で返却。データが無い日は既定値+空配列。
+
+curl例:
+
+```bash
+curl -s 'http://127.0.0.1:3002/api/month?month=2025-09' | jq '.days[0]'
 ```
 
 ## 表示設定（月次グラフ/日次）
@@ -59,6 +97,7 @@ npx vitest -r
 - 高さは 14px 既定。判別しにくい場合は画面上で 18px に上げてから印刷。
 
 注意（配色について）
+
 - 印刷ビュー（`public/month_print.html`）は紙での視認性を優先するため、画面の配色そのままではなく、モノクロでも判別しやすいパターン（ストライプ等）でカテゴリを表現します。
 - 画面上の月次一覧は配色パレット（hc/mid/pastel）を用いますが、印刷時はパターン優先に切り替わります（機能上の仕様）。
 
@@ -66,18 +105,20 @@ npx vitest -r
 
 - 月次から日次へ遷移する際に `pal`（配色）を引き継ぎます。
 - 日次も URL / `localStorage` の `dailylog.pal` を読み取り `palette-*` を適用します。
-.
-├─ server.js               # API/静的配信（後で追加）
-├─ public/                 # フロント（後で追加）
-├─ data/                   # SQLite（Git 管理外）
-└─ tmp/docs/               # 私的ドキュメント（Git 管理外）
+  .
+  ├─ server.js # API/静的配信（後で追加）
+  ├─ public/ # フロント（後で追加）
+  ├─ data/ # SQLite（Git 管理外）
+  └─ tmp/docs/ # 私的ドキュメント（Git 管理外）
 
 ## 環境変数
+
 - `PORT`: リッスンポート（例: 3002）
 - `DATA_DIR`: SQLite の格納ディレクトリ（例: ./data）
 - `DB_FILE`: SQLite ファイル名（例: dailylog.db / `:memory:` ならメモリDB）
 - `AUTH_USER` / `AUTH_PASS`: 設定すると Basic 認証が有効
-```
+
+````
 
 ## 貢献ガイド
 
@@ -97,7 +138,7 @@ gh issue create \
   --title "feat: 〇〇を追加" \
   --body  "背景/方針/受け入れ基準（日本語）" \
   --label "priority:P1" --label "type:feature"
-```
+````
 
 ## 運用（参考）
 

--- a/public/month.html
+++ b/public/month.html
@@ -708,6 +708,22 @@
           buildTimegridCSS();
         }
         const days = daysInMonth(m);
+        // まず /api/month を試みる（失敗時は /api/day 多重へフォールバック）
+        let byDateData = new Map();
+        if (!useSample) {
+          try {
+            const r = await fetch(`api/month?month=${m}`);
+            if (r.ok) {
+              const mj = await r.json();
+              if (mj && Array.isArray(mj.days)) {
+                byDateData = new Map(mj.days.map((d) => [d.date, d]));
+              }
+            }
+          } catch (e) {
+            // ignore and fallback
+          }
+        }
+
         for (const d of days) {
           let j;
           if (useSample) {
@@ -715,6 +731,8 @@
               activities: samplePlanForDay(d, sampleId),
               ...sampleMetricsForDay(d, sampleId),
             };
+          } else if (byDateData.has(d)) {
+            j = byDateData.get(d);
           } else {
             const r = await fetch(`api/day?date=${d}`);
             j = await r.json();

--- a/tests/api/month.test.js
+++ b/tests/api/month.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../../src/app.js';
+
+describe('/api/month (JSON aggregate)', () => {
+  let app;
+  let close;
+
+  beforeEach(() => {
+    const r = createApp({ dbFile: ':memory:' });
+    app = r.app;
+    close = r.close;
+  });
+
+  afterEach(() => close?.());
+
+  it('400 on bad month format', async () => {
+    const r = await request(app).get('/api/month').query({ month: '2025/09' });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toBe('bad month');
+  });
+
+  it('aggregates days and activities for the month (includes empty days)', async () => {
+    // Seed two days in September
+    const d1 = {
+      date: '2025-09-01',
+      sleep_minutes: 300,
+      fatigue: { morning: 3, noon: 4, night: 5 },
+      mood: { morning: 6, noon: 7, night: 8 },
+      note: 'note1',
+      activities: [
+        { slot: 0, label: '睡眠', category: 'sleep' },
+        { slot: 3, label: '移動', category: 'move' },
+      ],
+    };
+    const d2 = {
+      date: '2025-09-15',
+      sleep_minutes: 420,
+      fatigue: { morning: 2, noon: 3, night: 4 },
+      mood: { morning: 5, noon: 6, night: 7 },
+      note: 'note2',
+      activities: [
+        { slot: 1, label: '家事', category: 'house' },
+        { slot: 2, label: '食事', category: 'meal' },
+      ],
+    };
+    await request(app).post('/api/day').send(d1).expect(200);
+    await request(app).post('/api/day').send(d2).expect(200);
+
+    const res = await request(app).get('/api/month').query({ month: '2025-09' });
+    expect(res.status).toBe(200);
+    expect(res.body.month).toBe('2025-09');
+    const arr = res.body.days;
+    expect(Array.isArray(arr)).toBe(true);
+    // Should contain at least our two days
+    const i1 = arr.findIndex((d) => d.date === '2025-09-01');
+    const i2 = arr.findIndex((d) => d.date === '2025-09-15');
+    expect(i1).toBeGreaterThanOrEqual(0);
+    expect(i2).toBeGreaterThan(i1);
+    // Verify payload for 2025-09-01
+    const one = arr[i1];
+    expect(one.sleep_minutes).toBe(300);
+    expect(one.fatigue).toEqual({ morning: 3, noon: 4, night: 5 });
+    expect(one.mood).toEqual({ morning: 6, noon: 7, night: 8 });
+    expect(one.activities).toEqual([
+      { slot: 0, label: '睡眠', category: 'sleep' },
+      { slot: 3, label: '移動', category: 'move' },
+    ]);
+    // Verify an empty day is present (e.g., 2025-09-02)
+    const empty = arr.find((d) => d.date === '2025-09-02');
+    expect(empty).toBeTruthy();
+    expect(empty.activities).toEqual([]);
+    expect(empty.sleep_minutes).toBe(0);
+  });
+});


### PR DESCRIPTION
関連 Issue: #98

概要:
- public/month.html のデータ取得を /api/month (1リクエスト) 優先に。未対応環境では /api/day 多重に自動フォールバック。

受け入れ基準:
- /api/month が 200 のときは追加リクエスト無しで月全体を描画。
- /api/month が 404/400 等のときも従来どおり描画される（後方互換）。

影響範囲:
- UI のみ。見た目・レイアウト変更なし。