### PR TITLE
infra: developブランチの検証環境（自動デプロイ/通知/別DB）

### DIFF
--- a/.github/workflows/deploy-alert.yml
+++ b/.github/workflows/deploy-alert.yml
@@ -2,7 +2,7 @@ name: Deploy Alerts
 
 on:
   workflow_run:
-    workflows: ['Deploy (production)']
+    workflows: ['Deploy (production)', 'Deploy (develop)']
     types: [completed]
 
 permissions:
@@ -22,7 +22,8 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const wr = context.payload.workflow_run;
-            const title = `infra: Deploy (production) 失敗通知`;
+            const isDev = wr.name === 'Deploy (develop)';
+            const title = isDev ? `infra: Deploy (develop) 失敗通知` : `infra: Deploy (production) 失敗通知`;
             const labels = ["type:infra", "priority:P0"]; // P0: 要即時対応
             const assignees = ["mo9mo9-uwu-mo9mo9"];
 
@@ -60,7 +61,8 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const title = `infra: Deploy (production) 失敗通知`;
+            const isDev = context.payload.workflow_run?.name === 'Deploy (develop)';
+            const title = isDev ? `infra: Deploy (develop) 失敗通知` : `infra: Deploy (production) 失敗通知`;
             const { data: issues } = await github.rest.issues.listForRepo({ owner, repo, state: 'open', per_page: 100, labels: 'type:infra,priority:P0' });
             const found = issues.find(i => i.title === title);
             if (found) {

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,0 +1,52 @@
+name: Deploy (develop)
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-develop
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: ${{ github.ref == 'refs/heads/develop' }}
+    runs-on: [self-hosted, dailylog-prod]
+    timeout-minutes: 15
+    environment: development
+    steps:
+      - name: Show host info
+        run: |
+          echo "runner:" $(uname -a)
+          node -v || true
+          npm -v || true
+      - name: Pull latest and install prod deps
+        working-directory: /srv/dailylog-develop
+        run: |
+          set -euxo pipefail
+          if [ ! -d .git ]; then
+            sudo -u dailylog git clone https://github.com/${{ github.repository }} /srv/dailylog-develop
+            cd /srv/dailylog-develop
+          fi
+          git fetch --prune --quiet origin
+          git reset --hard origin/develop
+          npm ci --omit=dev || npm ci --only=production
+      - name: Restart service
+        run: |
+          sudo systemctl restart dailylog-develop
+          sleep 2
+          systemctl is-active --quiet dailylog-develop
+      - name: Health check (200 or 401 is OK)
+        env:
+          PORT: 3003
+        run: |
+          set -euxo pipefail
+          CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:${PORT}/api/health || true)
+          if [ "$CODE" = "200" ] || [ "$CODE" = "401" ]; then
+            echo "Service reachable with HTTP $CODE"
+          else
+            echo "Unexpected health status: $CODE" >&2
+            exit 1
+          fi
+

--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ gh issue create \
 - サービス名: `dailylog.service`、作業ディレクトリ: `/srv/dailylog`。
 - 再起動: `sudo systemctl restart dailylog`、疎通: `curl -u $AUTH_USER:$AUTH_PASS http://127.0.0.1:$PORT/api/health`。
 
+### 検証環境（develop）
+
+- ブランチ: `develop`（main と同等の保護）
+- デプロイ: GitHub Actions "Deploy (develop)"（自動）
+- サービス: `dailylog-develop.service`、作業ディレクトリ: `/srv/dailylog-develop`、PORT=3003（`.env`で上書き可）、DBは `dailylog-dev.db` を推奨
+- ヘルス: `curl -i http://127.0.0.1:3003/api/health`
+- Funnel 公開: 本番 `/dailylog/` と分離し `/dailylog-dev/` で公開（運用設定側でパス分け）
+
 ### 本番ポートの統一（PORT=3002）
 
 - 目的: GitHub Actions の "Deploy (production)" が `http://127.0.0.1:3002/api/health` をヘルスチェックするため、実サーバの待受ポートも 3002 に統一します。

--- a/scripts/systemd/dailylog-develop.service
+++ b/scripts/systemd/dailylog-develop.service
@@ -8,6 +8,7 @@ Type=simple
 WorkingDirectory=/srv/dailylog-develop
 Environment=NODE_ENV=production
 Environment=PORT=3003
+Environment=BASE_PATH=/dailylog-dev
 EnvironmentFile=-/srv/dailylog-develop/.env
 ExecStart=/usr/bin/env node /srv/dailylog-develop/server.js
 Restart=always
@@ -22,4 +23,3 @@ ReadWritePaths=/srv/dailylog-develop /srv/dailylog-develop/data
 
 [Install]
 WantedBy=multi-user.target
-

--- a/scripts/systemd/dailylog-develop.service
+++ b/scripts/systemd/dailylog-develop.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=DailyLog (develop) service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/srv/dailylog-develop
+Environment=NODE_ENV=production
+Environment=PORT=3003
+EnvironmentFile=-/srv/dailylog-develop/.env
+ExecStart=/usr/bin/env node /srv/dailylog-develop/server.js
+Restart=always
+RestartSec=3
+User=dailylog
+Group=dailylog
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=read-only
+ReadWritePaths=/srv/dailylog-develop /srv/dailylog-develop/data
+
+[Install]
+WantedBy=multi-user.target
+

--- a/scripts/systemd/dailylog.service
+++ b/scripts/systemd/dailylog.service
@@ -11,6 +11,7 @@ WorkingDirectory=/srv/dailylog
 # 環境設定: 本番想定。まず既定値、後段の .env で上書き可。
 Environment=NODE_ENV=production
 Environment=PORT=3002
+Environment=BASE_PATH=/dailylog
 EnvironmentFile=-/srv/dailylog/.env
 
 # 実行コマンド（Node は PATH 上にあるものを優先して検出）


### PR DESCRIPTION
関連 Issue: #102

- systemd: dailylog-develop.service（PORT=3003）を追加
- Actions: Deploy (develop) を追加
- Alerts: Deploy Alerts を develop にも適用（失敗で起票/成功でクローズ）
- Docs: README に develop 運用を追記

受け入れ基準:
- develop push で /srv/dailylog-develop にデプロイ→ dailylog-develop 稼働（health 200/401）
- 本番とは別ポート/DB/公開パス（/dailylog-dev/）で分離
- 通知が develop でも動作