### PR TITLE
chore: PR統合（#110, #111）— debugバッジ統一＋印刷非表示

### DIFF
--- a/public/month_print.html
+++ b/public/month_print.html
@@ -202,9 +202,13 @@
       }
       @media print {
         /* デバッグ表示は印刷には出さない */
-        #debug-banner { display: none !important; }
+        #debug-banner {
+          display: none !important;
+        }
         /* デバッグバッジも印刷には出さない */
-        .debug-badge { display: none !important; }
+        .debug-badge {
+          display: none !important;
+        }
         /* 印刷時はテーブルレイアウトで安定化 */
         .rows {
           display: table;


### PR DESCRIPTION
関連 Issue: #112

変更概要:
- PR #110 と #111 を統合。public/month_print.html の競合を解消。
- デバッグ表示は「ヘッダ内の小バッジ（.debug-badge）」に一本化。
- 印刷時は .debug-badge を非表示（#debug-banner も念のため非表示）。
- 既存の印刷レイアウト（テーブル化）と備考2行オプションの挙動は維持。

受け入れ観点:
- 画面: チェックボックス Debug=ON でヘッダ右側に小さな DEBUG バッジ表示。被りなし。
- 印刷(PDF含む): DEBUG は出力されない。列幅・行分割防止・2行クランプは従来通り。
- CI: eslint/prettier/vitest 通過。

テスト/CI:
- Prettier 実行: public/month_print.html を整形。
- vitest: 10/10 テスト成功。

統合後の運用:
- #110 / #111 には「統合先: このPR」をコメントして整理します。