### PR TITLE
chore(infra): 検証環境整備 — .env.example/README/セットアップスクリプト

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,24 @@
-# Web server
-# 例: 常時公開サーバでは 3002 を利用
-PORT=3002
+## DailyLog env example
 
-# Database
-# データ格納先ディレクトリ（相対/絶対どちらでも可）。存在しなければ起動時に作成されます。
+# 通常は .env を本番/検証それぞれの作業ディレクトリに配置します。
+# - 本番:   /srv/dailylog/.env
+# - 検証:   /srv/dailylog-develop/.env
+
+# 共通
+# SQLite の格納ディレクトリ（なければ自動作成）
 DATA_DIR=./data
-# SQLite ファイル名（`:memory:` を指定するとメモリDBでテスト用に起動します）
+# SQLite ファイル名（検証では dailylog-dev.db 推奨）
 DB_FILE=dailylog.db
 
-# Auth（任意）
-# 空欄のままなら認証は無効。値を設定すると Basic 認証が有効になります。
-AUTH_USER=
-AUTH_PASS=
+# 認証（任意）: 設定すると Basic 認証が有効化
+# AUTH_USER=
+# AUTH_PASS=
+
+# 公開パスのプレフィックス（例: 本番は /dailylog、検証は /dailylog-dev）
+# 空または / はルート配信
+BASE_PATH=
+
+# ポート（本番 3002、検証 3003 を推奨）
+# PORT=3002
+# PORT=3003
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI (PR)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   build:

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -49,4 +49,3 @@ jobs:
             echo "Unexpected health status: $CODE" >&2
             exit 1
           fi
-

--- a/DEV_CHANGELOG.md
+++ b/DEV_CHANGELOG.md
@@ -1,0 +1,1 @@
+dev deploy trigger 2025-09-04T23:41:39Z

--- a/public/month_print.html
+++ b/public/month_print.html
@@ -14,6 +14,22 @@
         --col-date: 12mm; /* 印刷時はmmで安定させる */
         --col-metrics: 36mm;
         --col-note: 56mm;
+        /* 備考の行数（1|2）。note-2 クラスで上書き */
+        --note-lines: 1;
+      }
+      /* develop検証用のデバッグ表示はヘッダ内の小バッジのみ（印刷時は非表示） */
+      .debug-badge {
+        display: inline-block;
+        margin-left: 8px;
+        padding: 2px 6px;
+        font-size: 12px;
+        font-weight: 800;
+        color: #fff;
+        background: #ff00a8;
+        border-radius: 3px;
+      }
+      :root.note-2 {
+        --note-lines: 2;
       }
       body {
         padding: 8px;
@@ -55,6 +71,7 @@
         margin-top: 6px;
         border-bottom: 1px solid #ccc;
         padding-bottom: 3px;
+        break-inside: avoid;
       }
       .colhead div {
         font-weight: 700;
@@ -126,9 +143,11 @@
         display: grid;
         grid-template-columns: var(--col-date) 1fr var(--col-metrics) var(--col-note);
         gap: 6px;
-        align-items: center;
+        align-items: start;
         border-bottom: 0.2mm solid #000;
         padding: 1px 0;
+        break-inside: avoid; /* 行分割防止 */
+        page-break-inside: avoid;
       }
       .rows .dayrow:first-child {
         border-top: 0.2mm solid #000;
@@ -152,12 +171,29 @@
         border: var(--cell-border);
         border-radius: var(--cell-radius);
       }
-      .metrics,
-      .note {
+      .metrics {
         font-size: 12px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+      }
+      .note {
+        font-size: 12px;
+        color: #444;
+        overflow: visible; /* ← 省略記号連鎖を断つ */
+        display: block;
+        min-width: 0; /* Grid内で折返し可能に */
+      }
+      /* 画面/印刷共通のデフォルト（1行）: innerを1行に見せる */
+      .note .note-inner {
+        display: block;
+        line-height: 1.2;
+        max-height: 1.2em; /* 既定1行 */
+        overflow: hidden;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+        white-space: normal;
+        text-overflow: clip;
       }
 
       @page {
@@ -165,6 +201,60 @@
         margin: 8mm;
       }
       @media print {
+        /* デバッグ表示は印刷には出さない */
+        #debug-banner {
+          display: none !important;
+        }
+        /* デバッグバッジも印刷には出さない */
+        .debug-badge {
+          display: none !important;
+        }
+        /* 印刷時はテーブルレイアウトで安定化 */
+        .rows {
+          display: table;
+          width: 100%;
+          table-layout: fixed;
+          border-collapse: separate;
+          border-spacing: 0 2px; /* 行間を維持 */
+        }
+        .dayrow {
+          display: table-row;
+          page-break-inside: avoid;
+        }
+        .daydate,
+        .graph,
+        .metrics,
+        .note {
+          display: table-cell;
+          vertical-align: top;
+        }
+        .daydate {
+          width: var(--col-date);
+        }
+        .metrics {
+          width: var(--col-metrics);
+        }
+        .note {
+          width: var(--col-note);
+        }
+
+        /* 複数行折返しを確実に */
+        .rows .dayrow .note {
+          white-space: normal !important;
+          text-overflow: clip !important;
+          min-width: 0;
+        }
+        .rows .dayrow .note .note-inner {
+          line-height: 1.2 !important;
+          /* Chrome印刷対策: WebKit系の2行クランプを利用 */
+          display: -webkit-box !important;
+          -webkit-box-orient: vertical !important;
+          -webkit-line-clamp: var(--note-lines) !important; /* 1 or 2 */
+          overflow: hidden !important;
+          overflow-wrap: anywhere !important;
+          word-break: break-word !important;
+          white-space: normal !important;
+        }
         .noprint {
           display: none;
         }
@@ -191,7 +281,15 @@
           <option value="6">サンプル6: 回復（休養）日</option>
         </select>
       </label>
+      <label style="display: flex; align-items: center; gap: 6px">
+        備考2行
+        <input type="checkbox" id="chkNote2" />
+      </label>
       <button id="btnPrint">印刷</button>
+      <label style="display: flex; align-items: center; gap: 6px" class="noprint">
+        Debug
+        <input type="checkbox" id="chkDebug" />
+      </label>
     </div>
 
     <div id="container"></div>
@@ -362,11 +460,20 @@
               c.title = String(a?.label || '');
               grid.appendChild(c);
             }
-            row.appendChild(grid);
+            const graphCell = document.createElement('div');
+            graphCell.className = 'graph';
+            graphCell.appendChild(grid);
+            row.appendChild(graphCell);
             const mm = Number(j?.sleep_minutes || 0);
             const f = j?.fatigue || {};
             const mmm = j?.mood || {};
-            const nt = String(j?.note || '').trim();
+            let nt = String(j?.note || '').trim();
+            // デモ用: 強制的に長文にして2行表示を確認
+            const forceTwo = (q.get('demo_note2') || '') === '1';
+            if (forceTwo) {
+              const base = nt || '長文: デモ用テキスト。折返しと2行表示の確認を行います。';
+              nt = base + '｜ケア計画の見直し・役割分担・頻度・負担分散について関係者へ共有予定。';
+            }
             const parts = [];
             if (mm > 0) parts.push(`睡${toHM(mm)}`);
             const fSum = (f.morning | 0) + (f.noon | 0) + (f.night | 0);
@@ -383,8 +490,11 @@
             row.appendChild(metricsEl);
             const noteEl = document.createElement('div');
             noteEl.className = 'note';
-            noteEl.textContent = nt;
             noteEl.title = nt;
+            const span = document.createElement('span');
+            span.className = 'note-inner';
+            span.textContent = nt;
+            noteEl.appendChild(span);
             row.appendChild(noteEl);
             rows.appendChild(row);
           }
@@ -408,6 +518,45 @@
             location.href = u.toString();
           });
         }
+
+        // 備考2行オプション
+        const linesParam = Math.max(1, Math.min(2, parseInt(q.get('note_lines') || '1', 10) || 1));
+        document.documentElement.classList.toggle('note-2', linesParam === 2);
+        const chk2 = document.getElementById('chkNote2');
+        if (chk2) {
+          chk2.checked = linesParam === 2;
+          chk2.addEventListener('change', () => {
+            const u = new URL(location.href);
+            u.searchParams.set('note_lines', chk2.checked ? '2' : '1');
+            location.href = u.toString();
+          });
+        }
+
+        // Debugバッジの表示切替
+        const dbg = (q.get('debug') || '0') === '1';
+        const chkDbg = document.getElementById('chkDebug');
+        if (chkDbg) chkDbg.checked = dbg;
+        function applyDebug(on) {
+          // ヘッダ内に小さなバッジのみを表示（印刷時は非表示）
+          const head = document.querySelector('.head');
+          if (!head) return;
+          const id = 'debug-badge';
+          head.querySelector('#' + id)?.remove();
+          if (on) {
+            const s = document.createElement('span');
+            s.className = 'debug-badge';
+            s.id = id;
+            s.textContent = 'DEBUG';
+            head.appendChild(s);
+          }
+        }
+        applyDebug(dbg);
+        if (chkDbg)
+          chkDbg.addEventListener('change', () => {
+            const u = new URL(location.href);
+            u.searchParams.set('debug', chkDbg.checked ? '1' : '0');
+            location.href = u.toString();
+          });
       })();
     </script>
   </body>

--- a/scripts/setup-develop-remote.sh
+++ b/scripts/setup-develop-remote.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 初回のみ: 検証環境(dailylog-develop) を /srv に用意し、systemd を有効化する。
+# 想定ホスト: Ubuntu (root または sudo)
+
+msg() { echo -e "\e[32m[setup]\e[0m $*"; }
+err() { echo -e "\e[31m[error]\e[0m $*" >&2; }
+
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  err "root で実行してください（sudo 推奨）"; exit 1
+fi
+
+USER_NAME=dailylog
+GROUP_NAME=$USER_NAME
+APP_DIR=/srv/dailylog-develop
+DATA_DIR=$APP_DIR/data
+UNIT_SRC=$(dirname "$0")/systemd/dailylog-develop.service
+UNIT_DST=/etc/systemd/system/dailylog-develop.service
+
+msg "ユーザ/グループ確認: $USER_NAME"
+if ! id "$USER_NAME" &>/dev/null; then
+  useradd -r -s /usr/sbin/nologin "$USER_NAME"
+fi
+
+msg "ディレクトリ作成: $APP_DIR"
+install -d -o "$USER_NAME" -g "$GROUP_NAME" "$APP_DIR"
+install -d -o "$USER_NAME" -g "$GROUP_NAME" "$DATA_DIR"
+
+if [[ ! -f "$APP_DIR/.env" ]]; then
+  msg "サンプル .env を作成 (PORT=3003 / BASE_PATH=/dailylog-dev)"
+  cat >"$APP_DIR/.env" <<'ENV'
+PORT=3003
+BASE_PATH=/dailylog-dev
+DATA_DIR=/srv/dailylog-develop/data
+DB_FILE=dailylog-dev.db
+# AUTH_USER=
+# AUTH_PASS=
+ENV
+  chown "$USER_NAME:$GROUP_NAME" "$APP_DIR/.env"
+fi
+
+msg "systemd ユニット配置: $UNIT_DST"
+install -m 0644 "$UNIT_SRC" "$UNIT_DST"
+systemctl daemon-reload
+systemctl enable --now dailylog-develop
+
+msg "完了: ランニング状態を確認します"
+systemctl --no-pager status dailylog-develop || true
+echo "Health: curl -i http://127.0.0.1:3003/api/health"
+


### PR DESCRIPTION
Closes #102

概要:
- 検証環境(develop)の運用を明確化：
  - `.env.example` 追加（検証/本番のサンプル。DB_FILE/BASE_PATH/PORT を明示）
  - README に検証環境の初回セットアップ/手動デプロイ/公開パスの運用を追記
  - `scripts/setup-develop-remote.sh` 追加（初回だけ実行するサーバ側セットアップを自動化）

受け入れ基準:
- develop への push で Deploy (develop) が走り、`http://127.0.0.1:3003/api/health` が 200/401（既存動作）。
- 検証サーバは `.env` に `PORT=3003`, `DB_FILE=dailylog-dev.db`, `BASE_PATH=/dailylog-dev` を設定するだけで稼働可能。
- Deploy Alerts は develop も監視（既存のまま）。

備考:
- アプリ実装やAPIには変更無し（運用/ドキュメントのみ）。