### PR TITLE
feat(ui,dev): dailylog-dev は Dev ハッシュ 表示

### DIFF
--- a/public/version.js
+++ b/public/version.js
@@ -17,7 +17,12 @@
       const small = document.querySelector('footer small');
       if (!small) return;
       const parts = [];
-      if (v?.commit && v.commit !== 'unknown') parts.push(String(v.commit));
+      // develop 環境（/dailylog-dev 配下）のときは "Dev <hash>" と表示
+      const isDev = (location.pathname || '').includes('/dailylog-dev');
+      if (v?.commit && v.commit !== 'unknown') {
+        const commitText = (isDev ? 'Dev ' : '') + String(v.commit);
+        parts.push(commitText);
+      }
       if (v?.built_at) parts.push(fmtBuiltAtMin(v.built_at));
       if (parts.length === 0) return;
       // Ensure delimiter prefix


### PR DESCRIPTION
関連 Issue: #138

- /dailylog-dev/ 配下のみ、©右のバージョン表示に Dev プレフィックスを付加
- 実装: `public/version.js` で `location.pathname` に `/dailylog-dev` を含むかで判定
- 本番(/dailylog/)は従来どおり（変更なし）