### PR TITLE
docs(readme): ブランチ保護の詳細はAGENTS.mdへ集約（参照リンク化）

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ gh issue create \
     gh auth status
     scripts/gh-branch-protect.sh
     ```
+
 ## 運用（参考）
 
 - 本番は N100 サーバ（Ubuntu）上で `systemd` 常駐、公開は Tailscale Funnel を使用。

--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ gh issue create \
   --label "priority:P1" --label "type:feature"
 ````
 
+## ブランチ保護（main/develop）
+
+- 本リポジトリのブランチ保護の詳細と再適用手順は AGENTS.md を参照してください。
+  - 参照: AGENTS.md → 「GitHub CLI（gh）の利用方針」内「ブランチ保護の適用（main/develop）」
+  - 実行例（要 gh ログイン）:
+    ```bash
+    gh auth status
+    scripts/gh-branch-protect.sh
+    ```
 ## 運用（参考）
 
 - 本番は N100 サーバ（Ubuntu）上で `systemd` 常駐、公開は Tailscale Funnel を使用。


### PR DESCRIPTION
関連 Issue: #145\n\n- READMEの重複節を参照リンクに置換\n- 詳細は AGENTS.md の該当節へ一本化